### PR TITLE
Add `ComplexHeatmap::pheatmap()` conversion option to `dittoHeatmap()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,8 @@ Suggests: plotly,
     knitr,
     BiocStyle,
     scRNAseq,
-    ggrastr
+    ggrastr,
+    ComplexHeatmap
 biocViews: 
     Software,
     Visualization,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,8 @@ Suggests: plotly,
     BiocStyle,
     scRNAseq,
     ggrastr,
-    ComplexHeatmap
+    ComplexHeatmap,
+    circlize
 biocViews: 
     Software,
     Visualization,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,8 +47,7 @@ Suggests: plotly,
     BiocStyle,
     scRNAseq,
     ggrastr,
-    ComplexHeatmap,
-    circlize
+    ComplexHeatmap
 biocViews: 
     Software,
     Visualization,

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -367,8 +367,8 @@ dittoHeatmap <- function(
 }
 
 # This function takes in a list of args formatted for pheatmap::pheatmap that
-# are to be passed on to ComplexHeatmap, and adjusts the colors input to help
-# remove need for the breaks input.
+# are to be passed on to ComplexHeatmap, and adjusts the breaks input to ensure
+# colors will match.
 #
 # Also adjusts the mat and scale arguments only to not duplicate the scaling
 # calculation. (scaling is run here to determine proper breaks.)

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -245,6 +245,7 @@ dittoHeatmap <- function(
     if (data.out) {
         OUT <- args
     } else if (complex) {
+        .error_if_no_complexHm()
         OUT <- do.call(ComplexHeatmap::pheatmap, args)
     } else {
         OUT <- do.call(pheatmap::pheatmap, args)

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -28,7 +28,7 @@
 #' (Can be useful for troubleshooting or customization.)
 #' @param highlight.features String vector of genes/metadata whose names you would like to show. Only these genes/metadata will be named in the resulting heatmap.
 #' @param highlight.genes Deprecated, use \code{highlight.features} instead.
-#' @param cluster_cols,border_color,legend_breaks,breaks,... other arguments passed to \code{\link{pheatmap}} directly.
+#' @param cluster_cols,border_color,legend_breaks,breaks,... other arguments passed to \code{\link[pheatmap]{pheatmap}} directly (or to \code{\link[ComplexHeatmap]{pheatmap}} if \code{complex = TRUE}).
 #' @param show_colnames,show_rownames,scale,annotation_col,annotation_colors arguments passed to \code{pheatmap} that are over-ruled by certain \code{dittoHeatmap} functionality:
 #' \itemize{
 #' \item show_colnames (& labels_col): if \code{cell.names.meta} is provided, pheatmaps's \code{labels_col} is utilized to show these names and \code{show_colnames} parameter is set to \code{TRUE}.
@@ -39,15 +39,18 @@
 #' but it is possible to set all or some manually. dittoSeq will just fill any left out annotations. Format is a named (annotation_col & annotation_row colnames) character vector list where individual color values can also be named.
 #' }
 #' @description Given a set of genes, cells/samples, and metadata names for column annotations, this function will retrieve the expression data for those genes and cells, and the annotation data for those cells.
-#' It will then utilize these data to make a heatmap using the \code{\link[pheatmap]{pheatmap}} function of the \code{pheatmap} package.
+#' It will then utilize these data to make a heatmap using the \code{\link[pheatmap]{pheatmap}} function of either the \code{pheatmap} (default) or \code{ComplexHeatmap} package.
 #'
 #' @return A \code{pheatmap} object.
 #'
-#' Alternatively, if \code{data.out} was set to \code{TRUE}, a list containing all arguments that would have be passed to pheatmap to generate such a heatmap.
+#' Alternatively, if \code{complex} is set to \code{TRUE}, a \code{\link[ComplexHeatmap]{Heatmap}}
+#' 
+#' Alternatively, if \code{data.out} is set to \code{TRUE}, a list containing all arguments that would have be passed to pheatmap to generate such a heatmap.
 #'
 #' @details
-#' This function serves as a wrapper for creating heatmaps from bulk or single-cell RNAseq data with \code{\link{pheatmap}},
+#' This function serves as a wrapper for creating heatmaps from bulk or single-cell RNAseq data with pheatmap::\code{\link{pheatmap}},
 #' by essentially automating the data extraction and annotation building steps.
+#' (Or alternatively with ComplexHeatmap::\code{\link[ComplexHeatmap]{pheatmap}} if \code{complex} is set to \code{true}.
 #'
 #' The function will extract the expression matrix for a set of \code{genes} and/or an optional subset of cells / samples to use via \code{cells.use},
 #' This matrix is either left as is, default (for scaling within the ultimate call to pheatmap), or if \code{scaled.to.max = TRUE}, is scaled by dividing each row by its maximum value.
@@ -63,7 +66,7 @@
 #'
 #' Such ordering happens by default for single-cell RNAseq data when any metadata are provided to \code{annot.by} as it is often unfeasible to cluster thousands of cells.
 #' \item A plot title can be added with \strong{\code{main}}.
-#' \item \strong{Gene or cell/sample names} can be hidden with \code{show_rownames} and \code{show_colnames}, respectively, or...
+#' \item Gene or cell/sample names can be hidden with \code{show_rownames} and \code{show_colnames}, respectively, or...
 #' \itemize{
 #' \item Particular features can also be selected for labeling using the \code{highlight.features} input.
 #' \item Names of all cells/samples can be replaced with the contents of a metadata slot using the \code{cell.names.meta} input.
@@ -75,6 +78,12 @@
 #' Note: cluster_cols will always be over-written to be \code{FALSE} when the input \code{order.by} is used above.
 #' \item \code{treeheight_row} and \code{treeheight_col} for setting how large the trees on the side/top should be drawn.
 #' \item \code{cutree_col} and \code{cutree_row} for spliting the heatmap based on kmeans clustering
+#' }
+#' \item When \code{complex} is set to \code{TRUE}, additional inputs for the \code{\link[ComplexHeatmap]{Heatmap}} function can be given as well.
+#' Some examples:
+#' \itemize{
+#' \item \code{use_raster} to have the heatmap rasterized/flattened to pixels which can make working with large heatmaps in a figure editor, like Illustrator, simpler.
+#' \item \code{name} to give the heatmap color scale a custom title.
 #' }
 #' }
 #'
@@ -103,7 +112,8 @@
 #' }
 #'
 #' @seealso
-#' \code{\link[pheatmap]{pheatmap}}, for how to add additional heatmap tweaks.
+#' pheatmap::\code{\link[pheatmap]{pheatmap}}, for how to add additional heatmap tweaks,
+#' OR or ComplexHeatmap::\code{\link[ComplexHeatmap]{pheatmap}} and \code{\link[ComplexHeatmap]{Heatmap}} for when you want to turn on rasterization or any additional customizations offered by this fantastic package.
 #'
 #' \code{\link{metaLevels}} for helping to create manual annotation_colors inputs.
 #' This function universally checks the options/levels of a string, factor (filled only by default), or numerical metadata.
@@ -141,11 +151,24 @@
 #'     order.by = "clustering")
 #'
 #' # When there are many cells, showing names becomes less useful.
-#' #   Names can be turned off with the show_colnames parameter.
-#' dittoHeatmap(myRNA, genes,
+#' #   Names can be turned off with the 'show_colnames' parameter.
+#' dittoHeatmap(scRNA, genes,
 #'     annot.by = "groups",
-#'     order.by = "groups",
 #'     show_colnames = FALSE)
+#' 
+#' # When theree are many many cells & genes, rasterization can be super useful
+#' # as well.
+#' #   Rasterization, or flattening of the distinct color objects to a matrix of
+#' #   pixels, is the default for large heatmaps in the ComplexHeatmap package,
+#' #   and you can have the heatmap rendered with this package (rather than the
+#' #   pheatmap package) by setting 'complex = TRUE'.
+#' #   Our data here is too small to hit that defaulting switch, so lets give
+#' #   the direct input, 'use_raster' as well:
+#' if (require(ComplexHeatmap)) { # Checks (and loads) if you have the package.
+#'     dittoHeatmap(scRNA, genes, annot.by = "groups", show_colnames = FALSE,
+#'         complex = TRUE,
+#'         use_raster = TRUE)
+#' }
 #'
 #' # Additionally, it is recommended for single-cell data that the parameter
 #' #   scaled.to.max be set to TRUE, or scale be "none" and turned off altogether,
@@ -154,6 +177,7 @@
 #' dittoHeatmap(myRNA, genes, annot.by = "groups",
 #'     order.by = "groups", show_colnames = FALSE,
 #'     scaled.to.max = TRUE)
+#' 
 #'
 #' @author Daniel Bunis and Jared Andrews
 #' @importFrom pheatmap pheatmap
@@ -243,12 +267,12 @@ dittoHeatmap <- function(
         show_rownames, scale, cluster_cols, border_color, legend_breaks,
         breaks, ...)
     
-    if (complex) {
+    if (data.out) {
+        OUT <- args
+    } else if (complex) {
         .error_if_no_complexHm()
         args <- .extra_adjustments_for_complex(args)
         OUT <- do.call(ComplexHeatmap::pheatmap, args)
-    } else if (data.out) {
-        OUT <- args
     } else {
         OUT <- do.call(pheatmap::pheatmap, args)
     }

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -6,6 +6,7 @@
 #' @param genes String vector, c("gene1","gene2","gene3",...) = the list of genes to put in the heatmap.
 #' If not provided, defaults to all genes of the object / assay.
 #' @param metas String vector, c("meta1","meta2","meta3",...) = the list of metadata variables to put in the heatmap.
+#' @param complex Logical which sets whether the heatmap should be generated with ComplexHeatmap (\code{TRUE}) versus pheatmap (\code{FALSE}, default).
 #' @param cells.use String vector of cells'/samples' names OR an integer vector specifying the indices of cells/samples which should be included.
 #' 
 #' Alternatively, a Logical vector, the same length as the number of cells in the object, which sets which cells to include.
@@ -186,6 +187,7 @@ dittoHeatmap <- function(
     border_color = NA,
     legend_breaks = NA,
     breaks = NA,
+    complex = FALSE,
     ...) {
 
     # If cells.use given as logical, populate as names.
@@ -242,6 +244,8 @@ dittoHeatmap <- function(
 
     if (data.out) {
         OUT <- args
+    } else if (complex) {
+        OUT <- do.call(ComplexHeatmap::pheatmap, args)
     } else {
         OUT <- do.call(pheatmap::pheatmap, args)
     }

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -350,7 +350,10 @@ dittoHeatmap <- function(
     
     if (is.null(args$breaks) || !is.null(args$breaks) && !is.na(args$breaks)) {
         args$color <- circlize::colorRamp2(
-            seq(min(args$breaks), max(args$breaks), length.out = length(args$color)),
+            breaks = seq(
+                min(args$breaks),
+                max(args$breaks),
+                length.out = length(args$color)),
             colors = args$color)
         breaks_not_given_by_user <- FALSE
     } else {
@@ -377,7 +380,10 @@ dittoHeatmap <- function(
         if (breaks_not_given_by_user) {
             limit <- max(abs(range(args$mat)))
             args$color <- circlize::colorRamp2(
-                seq(-limit, limit, length.out = length(args$color)),
+                breaks = seq(
+                    -1*limit,
+                    limit,
+                    length.out = length(args$color)),
                 colors = args$color)
         }
         

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -267,10 +267,6 @@ dittoHeatmap <- function(
         show_rownames, scale, cluster_cols, border_color, legend_breaks,
         breaks, ...)
     
-    if (complex) {
-        args <- .extra_adjustments_for_complex(args)
-    }
-    
     if (data.out) {
         OUT <- args
     } else if (complex) {
@@ -365,51 +361,6 @@ dittoHeatmap <- function(
 
     args
 }
-
-# This function takes in a list of args formatted for pheatmap::pheatmap that
-# are to be passed on to ComplexHeatmap, and adjusts the breaks input to ensure
-# colors will match.
-#
-# Also adjusts the mat and scale arguments only to not duplicate the scaling
-# calculation. (scaling is run here to determine proper breaks.)
-#
-# Overall, adjusts inputs to help equalize differences between default outputs.
-.extra_adjustments_for_complex <- function(args) {
-    
-    if (args$scale != "none" && identical(args$breaks[1], NA)) {
-        
-        # Perform scaling
-        if (args$scale == "row") {
-            if (any(is.na(args$mat))) {
-                args$mat <- (args$mat - apply(args$mat, 1, function(x) mean(x, na.rm = TRUE))) /
-                    apply(args$mat, 1, function(x) sd(x, na.rm = TRUE))
-            } else {
-                args$mat <- t(scale(t(args$mat)))
-            }
-        }
-        
-        if (args$scale == "column") {
-            if (any(is.na(args$mat))) {
-                args$mat <- t((t(args$mat) - apply(args$mat, 2, function(x) mean(x, na.rm = TRUE))) /
-                    apply(args$mat, 2, function(x) sd(x, na.rm = TRUE)))
-            } else {
-                args$mat <- scale(args$mat)
-            }
-        }
-        
-        args$scale <- "none"
-        
-        # Set breaks to be bimodal, centered on zero
-        limit <- max(abs(range(args$mat)))
-        args$breaks <- seq(
-                -1*limit,
-                limit,
-                length.out = length(args$color))
-    }
-    
-    args
-}
-
 
 # This next function creates pheatmap annotations_colors dataframe
     # list of character vectors, all named.

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -267,11 +267,14 @@ dittoHeatmap <- function(
         show_rownames, scale, cluster_cols, border_color, legend_breaks,
         breaks, ...)
     
+    if (complex) {
+        args <- .extra_adjustments_for_complex(args)
+    }
+    
     if (data.out) {
         OUT <- args
     } else if (complex) {
         .error_if_no_complexHm()
-        args <- .extra_adjustments_for_complex(args)
         OUT <- do.call(ComplexHeatmap::pheatmap, args)
     } else {
         OUT <- do.call(pheatmap::pheatmap, args)
@@ -373,16 +376,7 @@ dittoHeatmap <- function(
 # Overall, adjusts inputs to help equalize differences between default outputs.
 .extra_adjustments_for_complex <- function(args) {
     
-    if (!is.na(args$breaks[1])) {
-        
-        args$color <- circlize::colorRamp2(
-            breaks = seq(
-                min(args$breaks),
-                max(args$breaks),
-                length.out = length(args$color)),
-            colors = args$color)
-        
-    } else if (args$scale != "none") {
+    if (args$scale != "none" && identical(args$breaks[1], NA)) {
         
         # Perform scaling
         if (args$scale == "row") {
@@ -405,17 +399,13 @@ dittoHeatmap <- function(
         
         args$scale <- "none"
         
-        # Set breaks via the color input
+        # Set breaks to be bimodal, centered on zero
         limit <- max(abs(range(args$mat)))
-        args$color <- circlize::colorRamp2(
-            breaks = seq(
+        args$breaks <- seq(
                 -1*limit,
                 limit,
-                length.out = length(args$color)),
-            colors = args$color)
+                length.out = length(args$color))
     }
-    
-    args$breaks <- NA
     
     args
 }

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -203,6 +203,7 @@ dittoHeatmap <- function(
         highlight.features <- highlight.genes
     }
 
+    ### Obtain all needed data
     data <- .get_heatmap_data(object, genes, metas, assay, slot, cells.use)
     
     if (!is.null(cell.names.meta)) {
@@ -217,13 +218,12 @@ dittoHeatmap <- function(
         order_data <- NULL
     }
     
-    # Make the columns annotations data for colored annotation bars
+    # Make the columns annotations data
     if (is.null(annotation_col)) {
         annotation_col <- data.frame(row.names = cells.use)
     } else if (!all(cells.use %in% rownames(annotation_col))) {
         stop("rows of 'annotation_col' must be cell/sample names of all cells/samples being displayed")
     }
-    
     if (!is.null(annot.by)) {
         annotation_col <- rbind(
             as.data.frame(getMetas(object, names.only = FALSE)[cells.use, annot.by, drop = FALSE]),
@@ -235,22 +235,22 @@ dittoHeatmap <- function(
         main <- NA
     }
     
+    ### Prep inputs for heatmap contructor calls
     args <- .prep_ditto_heatmap(
         data, cells.use, all.cells, cell.names, order_data, main,
         heatmap.colors, scaled.to.max, heatmap.colors.max.scaled, annot.colors,
         annotation_col, annotation_colors, highlight.features, show_colnames,
         show_rownames, scale, cluster_cols, border_color, legend_breaks,
         breaks, ...)
-
+    
     if (data.out) {
-        OUT <- args
+        return(args)
     } else if (complex) {
         .error_if_no_complexHm()
-        OUT <- do.call(ComplexHeatmap::pheatmap, args)
+        return(do.call(ComplexHeatmap::pheatmap, args))
     } else {
-        OUT <- do.call(pheatmap::pheatmap, args)
+        return(do.call(pheatmap::pheatmap, args))
     }
-    OUT
 }
 
 .prep_ditto_heatmap <- function(

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -363,7 +363,8 @@ dittoHeatmap <- function(
         # Perform scaling
         if (args$scale == "row") {
             if (any(is.na(args$mat))) {
-                args$mat <- (args$mat - rowMeans(args$mat, na.rm = TRUE))/rowSds(args$mat, na.rm = TRUE)
+                args$mat <- (args$mat - apply(args$mat, 1, function(x) mean(x, na.rm = TRUE))) /
+                    apply(args$mat, 1, function(x) sd(x, na.rm = TRUE))
             } else {
                 args$mat <- t(scale(t(args$mat)))
             }
@@ -371,7 +372,8 @@ dittoHeatmap <- function(
         
         if (args$scale == "column") {
             if (any(is.na(args$mat))) {
-                args$mat <- t((t(args$mat) - colMeans(args$mat, na.rm = TRUE))/colSds(args$mat, na.rm = TRUE))
+                args$mat <- t((t(args$mat) - apply(args$mat, 2, function(x) mean(x, na.rm = TRUE))) /
+                    apply(args$mat, 2, function(x) sd(x, na.rm = TRUE)))
             } else {
                 args$mat <- scale(args$mat)
             }

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,3 +27,9 @@
         stop("ggrastr installation required for using rasterization with dittoScatterPlot plotters.")
     }
 }
+
+.error_if_no_complexHm <- function() {
+    if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
+        stop("ComplexHeatmap installation required for using `do.raster` or `complex` in dittoHeatmap.")
+    }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,7 +29,9 @@
 }
 
 .error_if_no_complexHm <- function() {
-    if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
-        stop("ComplexHeatmap installation required for using `do.raster` or `complex` in dittoHeatmap.")
+    if (!requireNamespace("ComplexHeatmap", quietly = TRUE) ||
+        !requireNamespace("circlize", quietly = TRUE)) {
+        stop("ComplexHeatmap & circlize installation required for using `complex` in dittoHeatmap.",
+             "\nInstall with BiocManager::install('ComplexHeatmap') and install.packages('circlize').")
     }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,9 +29,8 @@
 }
 
 .error_if_no_complexHm <- function() {
-    if (!requireNamespace("ComplexHeatmap", quietly = TRUE) ||
-        !requireNamespace("circlize", quietly = TRUE)) {
-        stop("ComplexHeatmap & circlize installation required for using `complex` in dittoHeatmap.",
-             "\nInstall with BiocManager::install('ComplexHeatmap') and install.packages('circlize').")
+    if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
+        stop("ComplexHeatmap installation required for using `complex` in dittoHeatmap.",
+             "\nInstall with BiocManager::install('ComplexHeatmap').")
     }
 }

--- a/man/dittoHeatmap.Rd
+++ b/man/dittoHeatmap.Rd
@@ -87,22 +87,25 @@ Default is a ramp from white to red with 25 slices.}
 but it is possible to set all or some manually. dittoSeq will just fill any left out annotations. Format is a named (annotation_col & annotation_row colnames) character vector list where individual color values can also be named.
 }}
 
-\item{cluster_cols, border_color, legend_breaks, breaks, ...}{other arguments passed to \code{\link{pheatmap}} directly.}
+\item{cluster_cols, border_color, legend_breaks, breaks, ...}{other arguments passed to \code{\link[pheatmap]{pheatmap}} directly (or to \code{\link[ComplexHeatmap]{pheatmap}} if \code{complex = TRUE}).}
 
 \item{complex}{Logical which sets whether the heatmap should be generated with ComplexHeatmap (\code{TRUE}) versus pheatmap (\code{FALSE}, default).}
 }
 \value{
 A \code{pheatmap} object.
 
-Alternatively, if \code{data.out} was set to \code{TRUE}, a list containing all arguments that would have be passed to pheatmap to generate such a heatmap.
+Alternatively, if \code{complex} is set to \code{TRUE}, a \code{\link[ComplexHeatmap]{Heatmap}}
+
+Alternatively, if \code{data.out} is set to \code{TRUE}, a list containing all arguments that would have be passed to pheatmap to generate such a heatmap.
 }
 \description{
 Given a set of genes, cells/samples, and metadata names for column annotations, this function will retrieve the expression data for those genes and cells, and the annotation data for those cells.
-It will then utilize these data to make a heatmap using the \code{\link[pheatmap]{pheatmap}} function of the \code{pheatmap} package.
+It will then utilize these data to make a heatmap using the \code{\link[pheatmap]{pheatmap}} function of either the \code{pheatmap} (default) or \code{ComplexHeatmap} package.
 }
 \details{
-This function serves as a wrapper for creating heatmaps from bulk or single-cell RNAseq data with \code{\link{pheatmap}},
+This function serves as a wrapper for creating heatmaps from bulk or single-cell RNAseq data with pheatmap::\code{\link{pheatmap}},
 by essentially automating the data extraction and annotation building steps.
+(Or alternatively with ComplexHeatmap::\code{\link[ComplexHeatmap]{pheatmap}} if \code{complex} is set to \code{true}.
 
 The function will extract the expression matrix for a set of \code{genes} and/or an optional subset of cells / samples to use via \code{cells.use},
 This matrix is either left as is, default (for scaling within the ultimate call to pheatmap), or if \code{scaled.to.max = TRUE}, is scaled by dividing each row by its maximum value.
@@ -119,7 +122,7 @@ unless such an input has been provided by the user. See below for further detail
 
 Such ordering happens by default for single-cell RNAseq data when any metadata are provided to \code{annot.by} as it is often unfeasible to cluster thousands of cells.
 \item A plot title can be added with \strong{\code{main}}.
-\item \strong{Gene or cell/sample names} can be hidden with \code{show_rownames} and \code{show_colnames}, respectively, or...
+\item Gene or cell/sample names can be hidden with \code{show_rownames} and \code{show_colnames}, respectively, or...
 \itemize{
 \item Particular features can also be selected for labeling using the \code{highlight.features} input.
 \item Names of all cells/samples can be replaced with the contents of a metadata slot using the \code{cell.names.meta} input.
@@ -131,6 +134,12 @@ Some examples of useful \code{pheatmap} parameters are:
 Note: cluster_cols will always be over-written to be \code{FALSE} when the input \code{order.by} is used above.
 \item \code{treeheight_row} and \code{treeheight_col} for setting how large the trees on the side/top should be drawn.
 \item \code{cutree_col} and \code{cutree_row} for spliting the heatmap based on kmeans clustering
+}
+\item When \code{complex} is set to \code{TRUE}, additional inputs for the \code{\link[ComplexHeatmap]{Heatmap}} function can be given as well.
+Some examples:
+\itemize{
+\item \code{use_raster} to have the heatmap rasterized/flattened to pixels which can make working with large heatmaps in a figure editor, like Illustrator, simpler.
+\item \code{name} to give the heatmap color scale a custom title.
 }
 }
 }
@@ -194,11 +203,24 @@ dittoHeatmap(myRNA, genes,
     order.by = "clustering")
 
 # When there are many cells, showing names becomes less useful.
-#   Names can be turned off with the show_colnames parameter.
-dittoHeatmap(myRNA, genes,
+#   Names can be turned off with the 'show_colnames' parameter.
+dittoHeatmap(scRNA, genes,
     annot.by = "groups",
-    order.by = "groups",
     show_colnames = FALSE)
+
+# When theree are many many cells & genes, rasterization can be super useful
+# as well.
+#   Rasterization, or flattening of the distinct color objects to a matrix of
+#   pixels, is the default for large heatmaps in the ComplexHeatmap package,
+#   and you can have the heatmap rendered with this package (rather than the
+#   pheatmap package) by setting 'complex = TRUE'.
+#   Our data here is too small to hit that defaulting switch, so lets give
+#   the direct input, 'use_raster' as well:
+if (require(ComplexHeatmap)) { # Checks (and loads) if you have the package.
+    dittoHeatmap(scRNA, genes, annot.by = "groups", show_colnames = FALSE,
+        complex = TRUE,
+        use_raster = TRUE)
+}
 
 # Additionally, it is recommended for single-cell data that the parameter
 #   scaled.to.max be set to TRUE, or scale be "none" and turned off altogether,
@@ -208,9 +230,11 @@ dittoHeatmap(myRNA, genes, annot.by = "groups",
     order.by = "groups", show_colnames = FALSE,
     scaled.to.max = TRUE)
 
+
 }
 \seealso{
-\code{\link[pheatmap]{pheatmap}}, for how to add additional heatmap tweaks.
+pheatmap::\code{\link[pheatmap]{pheatmap}}, for how to add additional heatmap tweaks,
+OR or ComplexHeatmap::\code{\link[ComplexHeatmap]{pheatmap}} and \code{\link[ComplexHeatmap]{Heatmap}} for when you want to turn on rasterization or any additional customizations offered by this fantastic package.
 
 \code{\link{metaLevels}} for helping to create manual annotation_colors inputs.
 This function universally checks the options/levels of a string, factor (filled only by default), or numerical metadata.

--- a/man/dittoHeatmap.Rd
+++ b/man/dittoHeatmap.Rd
@@ -31,6 +31,7 @@ dittoHeatmap(
   border_color = NA,
   legend_breaks = NA,
   breaks = NA,
+  complex = FALSE,
   ...
 )
 }
@@ -87,6 +88,8 @@ but it is possible to set all or some manually. dittoSeq will just fill any left
 }}
 
 \item{cluster_cols, border_color, legend_breaks, breaks, ...}{other arguments passed to \code{\link{pheatmap}} directly.}
+
+\item{complex}{Logical which sets whether the heatmap should be generated with ComplexHeatmap (\code{TRUE}) versus pheatmap (\code{FALSE}, default).}
 }
 \value{
 A \code{pheatmap} object.

--- a/tests/testthat/test-Heatmap-complex.R
+++ b/tests/testthat/test-Heatmap-complex.R
@@ -396,3 +396,11 @@ test_that("scale and border_color pheatmap inputs function as expected", {
             border_color = "red"),
         "Heatmap")
 })
+
+test_that("Rasterization works for ComplexHeatmap", {
+    # Manual Check: zooming in drastically should reveal unequal row/column widths.
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE, genes = genes, object = seurat,
+            use_raster = TRUE, raster_quality = 1),
+        "Heatmap")
+})

--- a/tests/testthat/test-Heatmap-complex.R
+++ b/tests/testthat/test-Heatmap-complex.R
@@ -1,0 +1,398 @@
+# Tests for dittoHeatmap - ComplexHeatmap output
+# library(dittoSeq); library(testthat); source("setup.R"); source("test-Heatmap-complex.R")
+
+seurat$number <- as.numeric(seq_along(colnames(seurat)))
+seurat$number2 <- as.numeric(rev(seq_along(colnames(seurat))))
+genes <- getGenes(seurat)[1:9]
+metas <- c("score", "score2", "score3")
+
+test_that("Heatmap can be plotted for Seurat or SCE", {
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat),
+        "Heatmap")
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = sce),
+        "Heatmap")
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            metas = metas,
+            object = sce),
+        "Heatmap")
+})
+
+test_that("Heatmap data type can be adjusted", {
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            slot = "counts"), # normally raw.data, but as.Seurat......
+        "Heatmap")
+})
+
+# Set genes1:5 to have all zeros in logcounts in a new object
+sce2 <- sce
+assay(sce2,"logcounts")[1:5,] <- 0
+
+# Set metadata to zero as well
+sce2$score <- 0
+test_that("Heatmap gives warnings/errors when genes missing", {
+    # Function throws a warning when any genes are not captured in the target cells.
+    expect_warning(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = sce2,
+            cells.use = meta("number", seurat)<5),
+        "Gene(s) or metadata removed due to absence of non-zero values within the 'cells.use' subset", fixed = TRUE)
+    # Function throws an error when no genes provided are captured in the target cells.
+    expect_error(
+        dittoHeatmap(complex = TRUE,
+            genes = genes[1:5],
+            object = sce2,
+            cells.use = meta("number", seurat)<10),
+        "No target genes/metadata features have non-zero values in the 'cells.use' subset", fixed = TRUE)
+
+    # And now for metadata.
+    expect_warning(
+        dittoHeatmap(complex = TRUE,
+            genes = NULL,
+            metas = metas,
+            object = sce2,
+            cells.use = meta("number", seurat)<5),
+        "Gene(s) or metadata removed due to absence of non-zero values within the 'cells.use' subset", fixed = TRUE)
+    # Function throws an error when no metas provided are captured in the target cells.
+    expect_error(
+        dittoHeatmap(complex = TRUE,
+            genes = NULL,
+            metas = metas[1],
+            object = sce2,
+            cells.use = meta("number", seurat)<10),
+        "No target genes/metadata features have non-zero values in the 'cells.use' subset", fixed = TRUE)
+})
+
+test_that("Heatmap gives error when both genes and metas are not provided", {
+    # Function throws an error when no genes or metas are provided.
+    expect_error(
+        dittoHeatmap(complex = TRUE,
+            genes = NULL,
+            metas = NULL,
+            object = sce),
+        "No 'genes' or 'metas' requested", fixed = TRUE)
+})
+
+test_that("Heatmap gives error when both highlight.genes and highlight.features are provided", {
+    # Function throws an error when no genes or metas are provided.
+    expect_error(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = sce,
+            highlight.features = "gene1",
+            highlight.genes = "gene1"),
+        "you can only specify one of 'highlight.genes' or 'highlight.features'", fixed = TRUE)
+})
+
+########################
+##### Manual Check #####
+########################
+
+test_that("Heatmap title can be adjusted", {
+    ### Title chould be "Hello there!"
+    expect_s4_class(
+        print(dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            main = "Hello there!")),
+        "Heatmap")
+})
+
+test_that("Heatmap sample renaming by metadata works", {
+    ### Names should be numbers
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            cell.names.meta = "number"),
+        "Heatmap")
+})
+
+test_that("Heatmap can hide rownames/colnames", {
+    ### No colnames
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            show_colnames = TRUE),
+        "Heatmap")
+    ### No rownames
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            show_rownames = FALSE),
+        "Heatmap")
+})
+
+test_that("Heatmap highlight genes works", {
+    ### Only 1 label, gene1
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            show_colnames = FALSE,
+            show_rownames = FALSE,
+            highlight.features = "gene1"),
+        "Heatmap")
+})
+
+test_that("Heatmap can be scaled to max", {
+    ### Color bar should go from 0 to 1 and white to red
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            scaled.to.max = TRUE),
+        "Heatmap")
+})
+
+test_that("Heatmap colors can be adjusted", {
+    ### yellow to black to red
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            heatmap.colors = colorRampPalette(c("yellow", "black", "red"))(50)),
+        "Heatmap")
+    ### black to yellow, 0:1
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            scaled.to.max = TRUE,
+            heatmap.colors.max.scaled = colorRampPalette(c("black", "yellow"))(25)),
+        "Heatmap")
+})
+
+test_that("Heatmap annotations can be given & heatmaps can be ordered by metadata, expression, or user-input vector", {
+    # Works for expression
+    ### ordered by gene1
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            order.by = "gene1"),
+        "Heatmap")
+    # Works for metadata
+    ### ordered by groups
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            order.by = "groups",
+            annot.by = "groups"),
+        "Heatmap")
+    # Works with vectors provided
+    ### Ordered in REVERSE of number2
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = "number2",
+            order.by = seq_along(colnames(seurat))),
+        "Heatmap")
+})
+
+test_that("Heatmap annotations can be given & ordering can be adjusted and follows defaults", {
+    # Annotation bar = clusters
+    ### Cells should also be ordered by this (single-cell)
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = "clusters"),
+        "Heatmap")
+    # Samples should not be ordered by this (bulk)
+    ### CLustered
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = bulk,
+            annot.by = "clusters"),
+        "Heatmap")
+    # Clusters even though an order.by would be given
+    ### Clustered!
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = "clusters",
+            cluster_cols = TRUE),
+        "Heatmap")
+    # Ordering, but distinct from the first annotation
+    ### ordered by groups.
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = c("clusters", "groups"),
+            order.by = "groups"),
+        "Heatmap")
+})
+
+test_that("Heatmap can be ordered when also subset to certain cells", {
+    # Works for expression
+    ### Ordered by gene1
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            order.by = "gene1",
+            cells.use = meta("number", seurat)<20),
+        "Heatmap")
+    # Works for metadata
+    ### ordered by groups metadata
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = "groups",
+            cells.use = colnames(seurat)[meta("number", seurat)<20]),
+        "Heatmap")
+    # Works with vectors provided
+    ### ordered in REVERSE of the number annotations
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = "number2",
+            order.by = seq_along(colnames(seurat)),
+            cells.use = colnames(seurat)[meta("number", seurat)<20]),
+        "Heatmap")
+})
+
+test_that("Heatmap can be subset to certain cells by any method", {
+    # By logical
+    ### Few cells
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            cells.use = meta("number", seurat)<10), # Logical method
+        "Heatmap")
+    # By names
+    ### Same few cells
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            cells.use = colnames(seurat)[meta("number", seurat)<10]), # names method
+        "Heatmap")
+    # By indices
+    ### Same few cells
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            cells.use = 1:9), # names method
+        "Heatmap")
+})
+
+test_that("Heatmap annotation colors can be adjusted via annot.colors", {
+    # (via adjustment of the color pool)
+    ### red, yellow, blue, purple for clusters
+    ### green numeric (in order)
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = c("number","clusters"),
+            annot.colors = c("red", "yellow", "blue", "purple", "green3")),
+        "Heatmap")
+})
+
+test_that("Heatmap annotation colors can be adjusted via annotation_colors", {
+    color_list <- list(clusters = c('1' = "red",
+                                    '2' = "yellow",
+                                    '3' = "blue",
+                                    '4' = "purple"))
+    # Number color should change, but clusters should still be the same custom set as above.
+    ### red, yellow, blue, purple for clusters
+    ### dittoBlue for number
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = c("number","clusters"),
+            annotation_colors = color_list),
+        "Heatmap")
+    ### When annotation_colors provides all colors for annotation_col.
+    color_list <- list(clusters = c('1' = "red",
+                                    '2' = "yellow",
+                                    '3' = "blue",
+                                    '4' = "purple"))
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = c("clusters"),
+            annotation_colors = color_list),
+        "Heatmap")
+})
+
+test_that("Coloring works for discrete column and row annotations", {
+    ### column and row annotations, all discrete & all dittoColors
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = c("clusters", "groups"),
+            scaled.to.max = TRUE,
+            annotation_row = data.frame(
+                genes,
+                row.names = genes)),
+        "Heatmap")
+})
+
+test_that("Coloring works for continuous column and row annotations", {
+    ### column and row annotations, all numeric.
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = "number",
+            scaled.to.max = TRUE,
+            annotation_row = data.frame(
+                lab = seq_len(9),
+                row.names = genes),
+            cluster_rows = FALSE,
+            cluster_cols = FALSE),
+        "Heatmap")
+    ### column and row annotations, all numeric.
+    ### but column annotation bar flips, while legend stays the same.
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+            genes = genes,
+            object = seurat,
+            annot.by = "number2",
+            order.by = "number",
+            scaled.to.max = TRUE,
+            annotation_row = data.frame(
+                lab = seq_len(9),
+                row.names = genes),
+            cluster_rows = FALSE,
+            cluster_cols = FALSE),
+        "Heatmap")
+})
+
+test_that("scale and border_color pheatmap inputs function as expected", {
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,genes = genes, object = seurat,
+            scale = "none"),
+        "Heatmap")
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,genes = genes, object = seurat,
+            border_color = "red"),
+        "Heatmap")
+})

--- a/tests/testthat/test-Heatmap-complex.R
+++ b/tests/testthat/test-Heatmap-complex.R
@@ -357,38 +357,17 @@ test_that("Coloring works for discrete column and row annotations", {
 
 test_that("Coloring works for continuous column and row annotations", {
     ### column and row annotations, all numeric.
-    # expect_s4_class(
-    #     dittoHeatmap(complex = TRUE,
-    #         genes = genes,
-    #         object = seurat,
-    #         annot.by = "number",
-    #         scaled.to.max = TRUE,
-    #         annotation_row = data.frame(
-    #             lab = seq_along(genes),
-    #             row.names = genes),
-    #         cluster_rows = FALSE,
-    #         cluster_cols = FALSE),
-    #     "Heatmap")
-    # Check one at a time while CH:pheatmap has bug for numerics in both.
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
-                     genes = genes,
-                     object = seurat,
-                     annot.by = "number",
-                     scaled.to.max = TRUE,
-                     cluster_rows = FALSE,
-                     cluster_cols = FALSE),
-        "Heatmap")
-    expect_s4_class(
-        dittoHeatmap(complex = TRUE,
-                     genes = genes,
-                     object = seurat,
-                     scaled.to.max = TRUE,
-                     annotation_row = data.frame(
-                         lab = seq_along(genes),
-                         row.names = genes),
-                     cluster_rows = FALSE,
-                     cluster_cols = FALSE),
+            genes = genes,
+            object = seurat,
+            annot.by = "number",
+            scaled.to.max = TRUE,
+            annotation_row = data.frame(
+                lab = seq_along(genes),
+                row.names = genes),
+            cluster_rows = FALSE,
+            cluster_cols = FALSE),
         "Heatmap")
     ### column and row annotations, all numeric.
     ### but column annotation bar flips, while legend stays the same.
@@ -399,9 +378,9 @@ test_that("Coloring works for continuous column and row annotations", {
             annot.by = "number2",
             order.by = "number",
             scaled.to.max = TRUE,
-            # annotation_row = data.frame(
-            #     lab = seq_len(9),
-            #     row.names = genes),
+            annotation_row = data.frame(
+                lab = seq_len(9),
+                row.names = genes),
             cluster_rows = FALSE,
             cluster_cols = FALSE),
         "Heatmap")

--- a/tests/testthat/test-Heatmap-complex.R
+++ b/tests/testthat/test-Heatmap-complex.R
@@ -101,10 +101,10 @@ test_that("Heatmap gives error when both highlight.genes and highlight.features 
 test_that("Heatmap title can be adjusted", {
     ### Title chould be "Hello there!"
     expect_s4_class(
-        print(dittoHeatmap(complex = TRUE,
+        dittoHeatmap(complex = TRUE,
             genes = genes,
             object = seurat,
-            main = "Hello there!")),
+            main = "Hello there!"),
         "Heatmap")
 })
 
@@ -357,17 +357,38 @@ test_that("Coloring works for discrete column and row annotations", {
 
 test_that("Coloring works for continuous column and row annotations", {
     ### column and row annotations, all numeric.
+    # expect_s4_class(
+    #     dittoHeatmap(complex = TRUE,
+    #         genes = genes,
+    #         object = seurat,
+    #         annot.by = "number",
+    #         scaled.to.max = TRUE,
+    #         annotation_row = data.frame(
+    #             lab = seq_along(genes),
+    #             row.names = genes),
+    #         cluster_rows = FALSE,
+    #         cluster_cols = FALSE),
+    #     "Heatmap")
+    # Check one at a time while CH:pheatmap has bug for numerics in both.
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
-            genes = genes,
-            object = seurat,
-            annot.by = "number",
-            scaled.to.max = TRUE,
-            annotation_row = data.frame(
-                lab = seq_along(genes),
-                row.names = genes),
-            cluster_rows = FALSE,
-            cluster_cols = FALSE),
+                     genes = genes,
+                     object = seurat,
+                     annot.by = "number",
+                     scaled.to.max = TRUE,
+                     cluster_rows = FALSE,
+                     cluster_cols = FALSE),
+        "Heatmap")
+    expect_s4_class(
+        dittoHeatmap(complex = TRUE,
+                     genes = genes,
+                     object = seurat,
+                     scaled.to.max = TRUE,
+                     annotation_row = data.frame(
+                         lab = seq_along(genes),
+                         row.names = genes),
+                     cluster_rows = FALSE,
+                     cluster_cols = FALSE),
         "Heatmap")
     ### column and row annotations, all numeric.
     ### but column annotation bar flips, while legend stays the same.
@@ -378,9 +399,9 @@ test_that("Coloring works for continuous column and row annotations", {
             annot.by = "number2",
             order.by = "number",
             scaled.to.max = TRUE,
-            annotation_row = data.frame(
-                lab = seq_len(9),
-                row.names = genes),
+            # annotation_row = data.frame(
+            #     lab = seq_len(9),
+            #     row.names = genes),
             cluster_rows = FALSE,
             cluster_cols = FALSE),
         "Heatmap")

--- a/tests/testthat/test-Heatmap-complex.R
+++ b/tests/testthat/test-Heatmap-complex.R
@@ -364,7 +364,7 @@ test_that("Coloring works for continuous column and row annotations", {
             annot.by = "number",
             scaled.to.max = TRUE,
             annotation_row = data.frame(
-                lab = seq_len(9),
+                lab = seq_along(genes),
                 row.names = genes),
             cluster_rows = FALSE,
             cluster_cols = FALSE),

--- a/tests/testthat/test-Heatmap.R
+++ b/tests/testthat/test-Heatmap.R
@@ -141,8 +141,8 @@ test_that("Heatmap highlight genes works", {
         dittoHeatmap(
             genes = genes,
             object = seurat,
-            show.colnames = FALSE,
-            show.rownames = FALSE,
+            show_colnames = FALSE,
+            show_rownames = FALSE,
             highlight.features = "gene1"),
         "pheatmap")
 })
@@ -389,15 +389,7 @@ test_that("Coloring works for continuous column and row annotations", {
 test_that("scale and border_color pheatmap inputs function as expected", {
     expect_s3_class(
         dittoHeatmap(genes = genes, object = seurat,
-            scale = "column"),
-        "pheatmap")
-    expect_s3_class(
-        dittoHeatmap(genes = genes, object = seurat,
             scale = "none"),
-        "pheatmap")
-    expect_s3_class(
-        dittoHeatmap(genes = genes, object = seurat,
-            scale = "column"),
         "pheatmap")
     expect_s3_class(
         dittoHeatmap(genes = genes, object = seurat,

--- a/vignettes/dittoSeq.Rmd
+++ b/vignettes/dittoSeq.Rmd
@@ -4,7 +4,7 @@ author:
 - name: Daniel Bunis
   affiliation: Bakar Computational Health Sciences Institute, University of California San Francisco, San
   email: daniel.bunis@ucsf.edu
-date: "July 31st, 2020"
+date: "October 9th, 2020"
 output:
   BiocStyle::html_document:
     toc_float: true
@@ -28,7 +28,7 @@ dittoSeq is a tool built to enable analysis and visualization of single-cell
 and bulk RNA-sequencing data by novice, experienced, and color-blind coders.
 Thus, it provides many useful visualizations, which all utilize red-green
 color-blindness optimized colors by default, and which allow sufficient
-customizations, via discrete inputs, for out-of-the-box creation of
+customization, via discrete inputs, for out-of-the-box creation of
 publication-ready figures.
 
 For single-cell data, dittoSeq works directly with data pre-processed in other
@@ -512,7 +512,7 @@ dittoBarPlot(seurat, "ident", group.by = "Sample",
 
 This function is essentially a wrapper for generating heatmaps with pheatmap,
 but with the same automatic, user-friendly, data extraction, (subsetting,) and
-metadata integrations common to other dittoSeq functions.
+metadata integration common to other dittoSeq functions.
 
 For large, many cell, single-cell datasets, it can be necessary to turn off
 clustering by cells in generating the heatmap because the process is very
@@ -553,15 +553,22 @@ dittoHeatmap(seurat, genes,
 A subset of the supplied genes can be given to the `highlight.features` input to
 have names shown for just these genes.
 
+The heatmap can also be rendered by the ComplexHeatmap package, rather than by
+the pheatmap package (default), by setting `complex` to TRUE. This package
+offers a wide variety of distinct plot customization, including rasterization
+when the heatmap would be too complex for editing software like Illustrator.
+
 ```{r}
 # Highlight certain genes
-dittoHeatmap(seurat, genes,
-    annot.by = c("celltype", "Sample"),
-    highlight.features = genes[1:3])
+dittoHeatmap(seurat, genes, annot.by = c("celltype", "Sample"),
+    highlight.features = genes[1:3],
+    complex = TRUE)
 ```
 
 Additional tweaks can be added through other built in inputs or by providing
-additional inputs that get passed along to pheatmap (see `?pheatmap`).
+additional inputs that get passed along to pheatmap::pheatmap (see `?pheatmap`)
+or to ComplexHeatmap::pheatmap (see `?ComplexHeatmap::pheatmap` and 
+`?ComplexHeatmap::Heatmap` on which the former function relies.)
 
 ## Multi-Plotters
 
@@ -570,7 +577,7 @@ multiple variables all in one plot.  They make it easier to create summaries
 for many genes or many cell types without the need for writing loops.
 
 Some setup for these, let's roughly pick out the markers of delta cells in
-this dataset
+this data set
 
 ```{r}
 # Idents(seurat) <- "celltype"
@@ -610,7 +617,7 @@ plot each.
 
 `dittoPlotVarsAcrossGroups()` creates a dittoPlot-like representation where
 instead of representing samples/cells as in typical dittoPlots, each data
-point instead represents a gene (or metadata). More specifrically, the average
+point instead represents a gene (or metadata). More specifically, the average
 expression, within each x-grouping, of a gene (or value of a metadata).
 
 ```{r}
@@ -774,9 +781,6 @@ Compatible functions (**bold** = `hover.data` input also required):
 dittoDimPlot(seurat, "INS",
     do.hover = TRUE,
     hover.data = c("celltype", "Sample", "ENO1", "ident", "nCount_RNA"))
-dittoPlot(seurat, "INS", group.by = "celltype", plots = c("vlnplot", "jitter"),
-    do.hover = TRUE,
-    hover.data = c("celltype", "Sample", "ENO1", "ident", "nCount_RNA"))
 ```
 
 When the types of underlying data possible to be shown are constrained because
@@ -787,8 +791,35 @@ dittoPlotVarsAcrossGroups), just `do.hover` is enough:
 # These can be finicky to render in knitting, but still, example code:
 dittoBarPlot(seurat, "celltype", group.by = "Sample",
     do.hover = TRUE)
-dittoPlotVarsAcrossGroups(seurat, delta.genes, group.by = "celltype",
-    do.hover = TRUE)
+```
+
+## Rasterization / flattening to pixels
+
+Often, single-cell datasets have so many cells that working with plots that
+show data points for every cell in a vector-based graphics editor, such as
+Illustrator, becomes prohibitively computationally intensive. In such
+instances, it can be helpful to have the per-cell graphics layers flattened
+to a pixel representation. Generally, dittoSeq offers this capability for via
+`do.raster` and `raster.dpi` inputs.
+
+```{r}
+# Note: dpi gets re-set by the styling code of this vignette, so this is
+#   just a code example, but the plot won't be quite matched.
+dittoDimPlot(sce, "celltype",
+    do.raster = TRUE,
+    raster.dpi = 300)
+```
+
+For `dittoHeatmap()`, where the plotting itself is handled by an external,
+the control is a bit different and we rely on `?ComplexHeatmap::Heatmap`'s
+input for this. First, set `complex = TRUE` to have the heatmap rendered by
+ComplexHeatmap, then rasterization should be turned on by default when needed,
+but it can also be turned on manually with `use_raster = TRUE`.
+
+```{r}
+dittoHeatmap(seurat, genes, scaled.to.max = TRUE,
+    complex = TRUE,
+    use_raster = TRUE)
 ```
 
 # Session information


### PR DESCRIPTION
A major goal here is to give users the ability to have large heatmaps be rasterized via that option (defualt for large heatmaps) within this package.
Additionally, allows users to take advantage of the extensive customizability offered by this package.