### PR TITLE
Bug Fix: keep `split.by` factor level order when used with `do.label`

### DIFF
--- a/R/utils-plot-mods.R
+++ b/R/utils-plot-mods.R
@@ -86,9 +86,11 @@
     # Add text labels at/near the median x and y values for each group
     # (Dim and Scatter plots)
 
-    #Determine medians
+    # Determine medians
     if (is.null(split.by)) {
+        
         median.data <- .calc_center_medians(Target_data, col.use)
+        
     } else if (length(split.by)==1) {
         
         median.data <- NULL
@@ -104,6 +106,11 @@
             
             median.data <- rbind(median.data, level.med.dat)
         }
+        
+        # Ensure retention of factor level ordering
+        median.data[,split.by] <- .retain_factor_level_order(
+            median.data[,split.by], possible_factor = Target_data[,split.by])
+        
     } else if (length(split.by)==2) {
         
         median.data <- NULL
@@ -125,6 +132,12 @@
                 }
             }
         }
+        
+        # Ensure retention of factor level ordering
+        median.data[,split.by[1]] <- .retain_factor_level_order(
+            median.data[,split.by[1]], possible_factor = Target_data[,split.by[1]])
+        median.data[,split.by[2]] <- .retain_factor_level_order(
+            median.data[,split.by[2]], possible_factor = Target_data[,split.by[2]])
     }
 
     #Add labels
@@ -147,6 +160,14 @@
             }
         }
     p + do.call(geom.use, args)
+}
+
+.retain_factor_level_order <- function(new_data, possible_factor) {
+    if (is.factor(possible_factor)) {
+        factor(new_data, levels = levels(possible_factor))
+    } else {
+        new_data
+    }
 }
 
 .calc_center_medians <- function(x.y.group.df, group.col) {

--- a/tests/testthat/test-ScatterPlot.R
+++ b/tests/testthat/test-ScatterPlot.R
@@ -141,7 +141,7 @@ test_that("dittoScatterPlot can show trajectory curves", {
 })
 
 test_that("dittoScatterPlot with and without rasterization produces identical plots", {
-    # MANUAL CHECK: Should be indentical
+    # MANUAL CHECK: Should be identical
     expect_s3_class(
         dittoScatterPlot(
             gene, cont, object = seurat, do.raster = TRUE),
@@ -149,5 +149,37 @@ test_that("dittoScatterPlot with and without rasterization produces identical pl
     expect_s3_class(
         dittoScatterPlot(
             gene, gene, object = seurat),
+        "ggplot")
+})
+
+test_that("do.label doesn't cause ignorance of split.by factor level ordering", {
+    
+    # Set two metadata as factors with non-default levels ordering
+    seurat$groups_rev <- factor(seurat$groups, levels = rev(unique(seurat$groups)))
+    seurat$clusters_rev <- factor(seurat$clusters, levels = 4:1)
+    
+    ### MANUAL CHECK: Should be identical aside from the lack of labels in #2 and #4
+    # One `split.by`
+    expect_s3_class(
+        dittoScatterPlot(
+            gene, cont, disc, object = seurat,
+            split.by = "groups_rev", do.label = FALSE),
+        "ggplot")
+    expect_s3_class(
+        dittoScatterPlot(
+            gene, cont, disc, object = seurat,
+            split.by = "groups_rev", do.label = TRUE),
+        "ggplot")
+    
+    # Two `split.by`
+    expect_s3_class(
+        dittoScatterPlot(
+            gene, cont, disc, object = seurat,
+            split.by = c("groups_rev", "clusters_rev"), do.label = FALSE),
+        "ggplot")
+    expect_s3_class(
+        dittoScatterPlot(
+            gene, cont, disc, object = seurat,
+            split.by = c("groups_rev", "clusters_rev"), do.label = TRUE),
         "ggplot")
 })


### PR DESCRIPTION
Addresses #65 