### PR TITLE
Allow utilization of SE/SCE rowData values as gene names.

### DIFF
--- a/R/DittoDimPlot.R
+++ b/R/DittoDimPlot.R
@@ -68,6 +68,7 @@
 #' \item{"z-score": scaled with the scale() function to produce a relative-to-mean z-score representation}
 #' \item{"relative.to.max": divided by the maximum expression value to give percent of max values between [0,1]}
 #' }
+#' @param swap.rownames String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).
 #' @param main String, sets the plot title.
 #' Default title is automatically generated if not given a specific value.  To remove, set to \code{NULL}.
 #' @param sub String, sets the plot subtitle
@@ -261,6 +262,7 @@ dittoDimPlot <- function(
     assay = .default_assay(object),
     slot = .default_slot(object),
     adjustment = NULL,
+    swap.rownames = NULL,
     color.panel = dittoColors(),
     colors = seq_along(color.panel),
     shape.panel = c(16,15,17,23,25,8),
@@ -340,7 +342,7 @@ dittoDimPlot <- function(
         extra.vars, cells.use,
         show.others, size, opacity, color.panel, colors,
         split.nrow, split.ncol, NA, NA, NA, NA, NA, NA,
-        assay, slot, adjustment, assay, slot, adjustment,
+        assay, slot, adjustment, assay, slot, adjustment, swap.rownames,
         shape.panel, rename.var.groups, rename.shape.groups,
         min.color, max.color, min, max, order,
         xlab, ylab, main, sub, theme,

--- a/R/DittoScatterPlot.R
+++ b/R/DittoScatterPlot.R
@@ -188,6 +188,7 @@ dittoScatterPlot <- function(
     assay.extra = .default_assay(object),
     slot.extra = .default_slot(object),
     adjustment.extra = NULL,
+    swap.rownames = NULL,
     shape.panel = c(16,15,17,23,25,8),
     rename.color.groups = NULL,
     rename.shape.groups = NULL,
@@ -248,6 +249,7 @@ dittoScatterPlot <- function(
         adjustment.color = adjustment.color,
         assay.extra = assay.extra, slot.extra = slot.extra,
         adjustment.extra = adjustment.extra,
+        swap.rownames = swap.rownames,
         do.hover, hover.data, hover.assay, hover.slot, hover.adjustment,
         rename.color.groups, rename.shape.groups)
 

--- a/R/dittoDotPlot.R
+++ b/R/dittoDotPlot.R
@@ -148,6 +148,7 @@ dittoDotPlot <- function(
     assay = .default_assay(object),
     slot = .default_slot(object),
     adjustment = NULL,
+    swap.rownames = NULL,
     do.hover = FALSE,
     main = NULL,
     sub = NULL,
@@ -179,7 +180,7 @@ dittoDotPlot <- function(
         object, vars, group.by,
         list(summary.fxn.color, summary.fxn.size),
         c("color", "size"),
-        cells.use, assay, slot, adjustment, do.hover)
+        cells.use, assay, slot, adjustment, swap.rownames, do.hover)
     data$var <- factor(data$var, levels = vars)
     data$grouping <-
         .rename_and_or_reorder(data$grouping, y.reorder, y.labels)
@@ -289,9 +290,11 @@ dittoDotPlot <- function(
     assay,
     slot,
     adjustment,
+    swap.rownames,
     do.hover,
     numeric.only = TRUE) {
     
+    object <- .swap_rownames(object, swap.rownames)
     groupings <- meta(group.by, object)[cells.use]
 
     ### Grab (and adjust) vars data per cell/sample

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -11,6 +11,7 @@
 #' 
 #' Alternatively, a Logical vector, the same length as the number of cells in the object, which sets which cells to include.
 #' @param assay,slot single strings or integer that set which expression data to use. See \code{\link{gene}} for more information about how defaults for these are filled in when not provided.
+#' @param swap.rownames String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).
 #' @param order.by Single string or numeric vector which sets the ordering of cells/samples.
 #' Can be the name of a gene, or metadata slot.
 #' Alternatively, can be a numeric vector of length equal to the total number of cells/samples in object.
@@ -193,6 +194,7 @@ dittoHeatmap <- function(
     cell.names.meta = NULL,
     assay = .default_assay(object),
     slot = .default_slot(object),
+    swap.rownames = NULL,
     heatmap.colors = colorRampPalette(c("blue", "white", "red"))(50),
     scaled.to.max = FALSE,
     heatmap.colors.max.scaled = colorRampPalette(c("white", "red"))(25),
@@ -226,6 +228,8 @@ dittoHeatmap <- function(
     }
 
     ### Obtain all needed data
+    object <- .swap_rownames(object, swap.rownames)
+    
     data <- .get_heatmap_data(object, genes, metas, assay, slot, cells.use)
     
     if (!is.null(cell.names.meta)) {

--- a/R/dittoHex.R
+++ b/R/dittoHex.R
@@ -165,6 +165,7 @@ dittoDimHex <- function(
     assay = .default_assay(object),
     slot = .default_slot(object),
     adjustment = NULL,
+    swap.rownames = NULL,
     assay.extra = assay,
     slot.extra = slot,
     adjustment.extra = adjustment,
@@ -231,6 +232,7 @@ dittoDimHex <- function(
         extra.vars, cells.use, color.panel, colors,
         split.nrow, split.ncol, NA, NA, NA, NA, NA, NA,
         assay, slot, adjustment, assay.extra, slot.extra, adjustment.extra,
+        swap.rownames,
         min.density, max.density, min.color, max.color,
         min.opacity, max.opacity, min, max,
         rename.color.groups, xlab, ylab, main, sub, theme,
@@ -290,6 +292,7 @@ dittoScatterHex <- function(
     assay.extra = .default_assay(object),
     slot.extra = .default_slot(object),
     adjustment.extra = NULL,
+    swap.rownames = NULL,
     min.density = NA,
     max.density = NA,
     min.color = "#F0E442",
@@ -334,8 +337,8 @@ dittoScatterHex <- function(
         object, cells.use, x.var, y.var, color.var, shape.by=NULL, split.by,
         extra.vars, assay.x, slot.x, adjustment.x, assay.y, slot.y,
         adjustment.y, assay.color, slot.color, adjustment.color, assay.extra,
-        slot.extra, adjustment.extra, rename.color.groups = rename.color.groups
-    )
+        slot.extra, adjustment.extra, swap.rownames = swap.rownames,
+        rename.color.groups = rename.color.groups)
     data <- all_data[cells.use,]
 
     # Parse coloring methods
@@ -547,6 +550,7 @@ dittoScatterHex <- function(
     assay.extra,
     slot.extra,
     adjustment.extra,
+    swap.rownames = NULL,
     do.hover = FALSE,
     hover.data = NULL,
     hover.assay = NULL,
@@ -557,6 +561,7 @@ dittoScatterHex <- function(
     ) {
 
     all.cells <- .all_cells(object)
+    object <- .swap_rownames(object, swap.rownames)
     
     # Make dataframe
     vars <- list(x.var, y.var, color.var, shape.by)

--- a/R/dittoPlot.R
+++ b/R/dittoPlot.R
@@ -518,7 +518,7 @@ dittoBoxPlot <- function(..., plots = c("boxplot","jitter")){ dittoPlot(..., plo
     object, main.var, group.by = "Sample", color.by = group.by,
     extra.vars = NULL, cells.use = NULL,
     assay, slot, adjustment,
-    swap.rownames = FALSE,
+    swap.rownames = NULL,
     do.hover = FALSE, hover.data = c(main.var, extra.vars)) {
 
     # Populate cells.use with a list of names if it was given anything else.

--- a/R/dittoPlot.R
+++ b/R/dittoPlot.R
@@ -33,6 +33,7 @@
 #' \item{"z-score": scaled with the scale() function to produce a relative-to-mean z-score representation}
 #' \item{"relative.to.max": divided by the maximum expression value to give percent of max values between [0,1]}
 #' }
+#' @param swap.rownames String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).
 #' @param do.hover Logical. Default = \code{FALSE}.
 #' If set to \code{TRUE} (and if there is a "jitter" in \code{plots}): object will be converted to a ggplotly object so that data about individual cells will be displayed when you hover your cursor over the jitter points,
 #'
@@ -214,6 +215,7 @@ dittoPlot <- function(
     assay = .default_assay(object),
     slot = .default_slot(object),
     adjustment = NULL,
+    swap.rownames = NULL,
     do.hover = FALSE,
     hover.data = var,
     color.panel = dittoColors(),
@@ -278,7 +280,7 @@ dittoPlot <- function(
     # Grab the data
     Target_data <- .dittoPlot_data_gather(object, var, group.by, color.by,
         c(shape.by,split.by,extra.vars), cells.use, assay, slot, adjustment,
-        do.hover, hover.data)$Target_data
+        swap.rownames, do.hover, hover.data)$Target_data
     Target_data$grouping <-
         .rename_and_or_reorder(Target_data$grouping, x.reorder, x.labels)
 
@@ -513,7 +515,10 @@ dittoBoxPlot <- function(..., plots = c("boxplot","jitter")){ dittoPlot(..., plo
 }
 
 .dittoPlot_data_gather <- function(
-    object, main.var, group.by = "Sample", color.by = group.by, extra.vars = NULL, cells.use = NULL, assay, slot, adjustment,
+    object, main.var, group.by = "Sample", color.by = group.by,
+    extra.vars = NULL, cells.use = NULL,
+    assay, slot, adjustment,
+    swap.rownames = FALSE,
     do.hover = FALSE, hover.data = c(main.var, extra.vars)) {
 
     # Populate cells.use with a list of names if it was given anything else.
@@ -523,7 +528,7 @@ dittoBoxPlot <- function(..., plots = c("boxplot","jitter")){ dittoPlot(..., plo
     ### Make dataframe for storing the plotting data:
     full_data <- data.frame(
         var.data = .var_OR_get_meta_or_gene(
-            main.var, object, assay, slot, adjustment),
+            main.var, object, assay, slot, adjustment, swap.rownames),
         grouping = meta(group.by, object),
         color = meta(color.by, object),
         row.names = all.cells)

--- a/R/dittoPlotVarsAcrossGroups.R
+++ b/R/dittoPlotVarsAcrossGroups.R
@@ -139,6 +139,7 @@ dittoPlotVarsAcrossGroups <- function(
     assay = .default_assay(object),
     slot = .default_slot(object),
     adjustment = "z-score",
+    swap.rownames = NULL,
     do.hover = FALSE,
     main = NULL,
     sub = NULL,
@@ -189,7 +190,7 @@ dittoPlotVarsAcrossGroups <- function(
     # Create data table summarizing vars data for each group
     data <- .data_gather_summarize_vars_by_groups(
         object, vars, group.by, list(summary.fxn), "var.data", cells.use,
-        assay, slot, adjustment, do.hover)
+        assay, slot, adjustment, swap.rownames, do.hover)
     
     data$grouping <-
         .rename_and_or_reorder(data$grouping, x.reorder, x.labels)

--- a/R/gene-getters.R
+++ b/R/gene-getters.R
@@ -1,10 +1,9 @@
 #### isGene: Is this the name of a gene in my dataset? ####
 #' Tests if input is the name of a gene in a target object.
 #'
+#' @inheritParams gene
 #' @param test String or vector of strings, the "potential.gene.name"(s) to check for.
-#' @param object A Seurat, SingleCellExperiment, or SummarizedExperiment object.
 #' @param assay single string or integer that sets which set of seq data inside the object to check.
-#' @param swap.rownames String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).
 #' @param return.values Logical which sets whether the function returns a logical \code{TRUE}/\code{FALSE} versus the \code{TRUE} \code{test} values . Default = \code{FALSE}
 #' REQUIRED, unless '\code{DEFAULT <- "object"}' has been run.
 #' @return Returns a logical vector indicating whether each instance in \code{test} is a rowname within the requested \code{assay} of the \code{object}.
@@ -55,9 +54,8 @@ isGene <- function(
 
 #' Returns the names of all genes of a target object.
 #'
-#' @param object A Seurat, SingleCellExperiment, or SummarizedExperiment object.
+#' @inheritParams gene
 #' @param assay Single string or integer that sets which set of seq data inside the object to check.
-#' @param swap.rownames String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).
 #' @return A string vector, returns the names of all genes of the \code{object} for the requested \code{assay}.
 #' @seealso
 #' \code{\link{isGene}} for returning all genes in an \code{object}

--- a/R/gene-getters.R
+++ b/R/gene-getters.R
@@ -4,6 +4,7 @@
 #' @param test String or vector of strings, the "potential.gene.name"(s) to check for.
 #' @param object A Seurat, SingleCellExperiment, or SummarizedExperiment object.
 #' @param assay single string or integer that sets which set of seq data inside the object to check.
+#' @param swap.rownames String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).
 #' @param return.values Logical which sets whether the function returns a logical \code{TRUE}/\code{FALSE} versus the \code{TRUE} \code{test} values . Default = \code{FALSE}
 #' REQUIRED, unless '\code{DEFAULT <- "object"}' has been run.
 #' @return Returns a logical vector indicating whether each instance in \code{test} is a rowname within the requested \code{assay} of the \code{object}.
@@ -37,9 +38,14 @@
 #' @author Daniel Bunis
 #' @export
 
-isGene <- function(test, object, assay = .default_assay(object),
-    return.values = FALSE) {
+isGene <- function(
+    test, object,
+    assay = .default_assay(object),
+    return.values = FALSE,
+    swap.rownames = NULL) {
 
+    object <- .swap_rownames(object, swap.rownames)
+    
     if (return.values) {
         return(test[isGene(test, object, assay, return.values=FALSE)])
     } else {
@@ -50,7 +56,8 @@ isGene <- function(test, object, assay = .default_assay(object),
 #' Returns the names of all genes of a target object.
 #'
 #' @param object A Seurat, SingleCellExperiment, or SummarizedExperiment object.
-#' @param assay single string or integer that sets which set of seq data inside the object to check.
+#' @param assay Single string or integer that sets which set of seq data inside the object to check.
+#' @param swap.rownames String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).
 #' @return A string vector, returns the names of all genes of the \code{object} for the requested \code{assay}.
 #' @seealso
 #' \code{\link{isGene}} for returning all genes in an \code{object}
@@ -73,7 +80,11 @@ isGene <- function(test, object, assay = .default_assay(object),
 #' @author Daniel Bunis
 #' @export
 
-getGenes <- function(object, assay = .default_assay(object)){
+getGenes <- function(
+    object, assay = .default_assay(object), swap.rownames = NULL) {
+    
+    object <- .swap_rownames(object, swap.rownames)
+    
     rownames(.which_data(object=object,assay = assay))
 }
 
@@ -99,6 +110,7 @@ getGenes <- function(object, assay = .default_assay(object)){
 #' @param adj.fxn A function which takes a vector (of metadata values) and returns a vector of the same length.
 #' 
 #' For example, \code{function(x) \{log2(x)\}} or \code{as.factor}
+#' @param swap.rownames String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).
 #' @return Returns the expression values of a gene for all cells/samples.
 #' @examples
 #' example(importDittoBulk, echo = FALSE)
@@ -128,7 +140,10 @@ getGenes <- function(object, assay = .default_assay(object)){
 gene <- function(
     gene, object,
     assay = .default_assay(object), slot = .default_slot(object),
-    adjustment = NULL, adj.fxn = NULL){
+    adjustment = NULL, adj.fxn = NULL,
+    swap.rownames = NULL) {
+    
+    object <- .swap_rownames(object, swap.rownames)
 
     if (!isGene(gene, object, assay)) {
         stop(dQuote(gene)," is not a gene of 'object'")

--- a/R/multi_plotters.R
+++ b/R/multi_plotters.R
@@ -229,7 +229,7 @@ multi_dittoPlot <- function(
 #' @param show.titles Logical which sets whether grouping-levels should be used as titles for the individual VaryCell plots. Default = TRUE.
 #' @param ncol,nrow Integers which set dimensions of the plot grid when \code{list.out = FALSE}.
 #' @param allcells.main String which adjusts the title of the allcells plot. Default = "All Cells".  Set to \code{NULL} to remove.
-#' @param ...,color.panel,colors,min,max,assay,slot,adjustment,data.out,do.hover additional parameters passed to \code{\link{dittoDimPlot}}.
+#' @param ...,color.panel,colors,min,max,assay,slot,adjustment,data.out,do.hover,swap.rownames additional parameters passed to \code{\link{dittoDimPlot}}.
 #' 
 #' All parameters of \code{\link{dittoDimPlot}} can be utilized and adjusted except for \code{cells.use}, \code{main}, and \code{legend.show} which are handled with alternative methods here.
 #' A few suggestions: \code{reduction.use} for setting which dimensionality reduction space to use.
@@ -318,12 +318,13 @@ multi_dittoDimPlotVaryCells <- function(
     color.panel = dittoColors(),
     colors = seq_along(color.panel),
     data.out = FALSE,
-    do.hover = FALSE
+    do.hover = FALSE,
+    swap.rownames = NULL
     ) {
     
     color.panel <- color.panel[colors]
     
-    var.data <- .var_OR_get_meta_or_gene(var, object, assay, slot, adjustment)
+    var.data <- .var_OR_get_meta_or_gene(var, object, assay, slot, adjustment, swap.rownames)
     numeric <- is.numeric(var.data)
     
     vary.data <- meta(vary.cells.meta, object)
@@ -346,8 +347,8 @@ multi_dittoDimPlotVaryCells <- function(
         ...,
         assay = assay, slot = slot, adjustment = adjustment,
         min = min, max = max,
-        data.out = data.out, do.hover = do.hover
-        )
+        data.out = data.out, do.hover = do.hover,
+        swap.rownames = swap.rownames)
     
     if (!is.null(plot.args$cells.use)) {
         stop("Further subsetting with 'cells.use' is not supported.")

--- a/R/utils-data-edit.R
+++ b/R/utils-data-edit.R
@@ -70,3 +70,19 @@
     }
     do.call(factor, args = rename.args)
 }
+
+.swap_rownames <- function(object, swap.rownames = NULL) {
+    
+    if (!identical(swap.rownames, NULL) && is(object, "SummarizedExperiment")) {
+        
+        if (!swap.rownames %in% names(SummarizedExperiment::rowData(object))) {
+            stop("'swap.rownames' is not a column of 'rowData(object)'")
+        }
+        
+        rownames(object) <- rowData(object)[,swap.rownames]
+    }
+    
+    object
+}
+
+

--- a/R/utils-getters.R
+++ b/R/utils-getters.R
@@ -35,11 +35,8 @@
 
 #' @importFrom SummarizedExperiment assay
 .which_data <- function(
-    assay = .default_assay(object), slot = .default_slot(object), object,
-    swap.rownames = NULL) {
+    assay = .default_assay(object), slot = .default_slot(object), object) {
     # Retrieves the required counts data from 'object'
-    
-    object <- .swap_rownames(object, swap.rownames)
 
     if (is(object,"SummarizedExperiment")) {
         return(SummarizedExperiment::assay(object, assay))
@@ -84,7 +81,7 @@
 .add_by_cell <- function(df = NULL, target, name, object,
     assay = .default_assay(object), slot = .default_slot(object),
     adjustment = NULL, reorder = NULL, relabels = NULL,
-    swap.rownames = NULL, mult = FALSE) {
+    mult = FALSE) {
 
     # Extracts metadata or gene expression if 'target' is the name of one,
     # or if length('target') = ncol(object), its values are used directly.
@@ -105,8 +102,6 @@
     if (is.null(df)) {
         df <- data.frame(row.names = .all_cells(object))
     }
-    
-    object <- .swap_rownames(object, swap.rownames)
 
     if (mult) {
         for (i in seq_along(target)) {

--- a/R/utils-getters.R
+++ b/R/utils-getters.R
@@ -35,8 +35,11 @@
 
 #' @importFrom SummarizedExperiment assay
 .which_data <- function(
-    assay = .default_assay(object), slot = .default_slot(object), object) {
+    assay = .default_assay(object), slot = .default_slot(object), object,
+    swap.rownames = NULL) {
     # Retrieves the required counts data from 'object'
+    
+    object <- .swap_rownames(object, swap.rownames)
 
     if (is(object,"SummarizedExperiment")) {
         return(SummarizedExperiment::assay(object, assay))
@@ -53,12 +56,16 @@
 
 .var_OR_get_meta_or_gene <- function(var, object,
     assay = .default_assay(object), slot = .default_slot(object),
-    adjustment = NULL) {
+    adjustment = NULL,
+    swap.rownames = NULL) {
     # Turns 'var' strings refering to genes or metadata into their associated data
     # Otherwise, returns 'var' with cellname names added.
 
     OUT <- var
+    
     cells <- .all_cells(object)
+    object <- .swap_rownames(object, swap.rownames)
+    
     if (length(var)==1 && is.character(var)) {
         if (isMeta(var, object)) {
             OUT <- meta(var, object)
@@ -76,7 +83,8 @@
 
 .add_by_cell <- function(df = NULL, target, name, object,
     assay = .default_assay(object), slot = .default_slot(object),
-    adjustment = NULL, reorder = NULL, relabels = NULL, mult = FALSE) {
+    adjustment = NULL, reorder = NULL, relabels = NULL,
+    swap.rownames = NULL, mult = FALSE) {
 
     # Extracts metadata or gene expression if 'target' is the name of one,
     # or if length('target') = ncol(object), its values are used directly.
@@ -97,6 +105,8 @@
     if (is.null(df)) {
         df <- data.frame(row.names = .all_cells(object))
     }
+    
+    object <- .swap_rownames(object, swap.rownames)
 
     if (mult) {
         for (i in seq_along(target)) {

--- a/man/dittoDimPlot.Rd
+++ b/man/dittoDimPlot.Rd
@@ -21,6 +21,7 @@ dittoDimPlot(
   assay = .default_assay(object),
   slot = .default_slot(object),
   adjustment = NULL,
+  swap.rownames = NULL,
   color.panel = dittoColors(),
   colors = seq_along(color.panel),
   shape.panel = c(16, 15, 17, 23, 25, 8),
@@ -127,6 +128,8 @@ See \code{\link{gene}} for more information.}
 \item{"z-score": scaled with the scale() function to produce a relative-to-mean z-score representation}
 \item{"relative.to.max": divided by the maximum expression value to give percent of max values between [0,1]}
 }}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 
 \item{color.panel}{String vector which sets the colors to draw from. \code{dittoColors()} by default, see \code{\link{dittoColors}} for contents.}
 

--- a/man/dittoDotPlot.Rd
+++ b/man/dittoDotPlot.Rd
@@ -22,6 +22,7 @@ dittoDotPlot(
   assay = .default_assay(object),
   slot = .default_slot(object),
   adjustment = NULL,
+  swap.rownames = NULL,
   do.hover = FALSE,
   main = NULL,
   sub = NULL,
@@ -75,6 +76,8 @@ Any function can be used as long as it takes in a numeric vector and returns a s
 \item{"z-score": centered and scaled to produce a relative-to-mean z-score representation}
 \item{NULL: Default, no adjustment}
 }}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 
 \item{do.hover}{Logical. Default = \code{FALSE}.
 If set to \code{TRUE} the object will be converted to an interactive plotly object in which underlying data for individual dots will be displayed when you hover your cursor over them.}

--- a/man/dittoHeatmap.Rd
+++ b/man/dittoHeatmap.Rd
@@ -15,6 +15,7 @@ dittoHeatmap(
   cell.names.meta = NULL,
   assay = .default_assay(object),
   slot = .default_slot(object),
+  swap.rownames = NULL,
   heatmap.colors = colorRampPalette(c("blue", "white", "red"))(50),
   scaled.to.max = FALSE,
   heatmap.colors.max.scaled = colorRampPalette(c("white", "red"))(25),
@@ -58,6 +59,8 @@ Alternatively, can be a numeric vector of length equal to the total number of ce
 \item{cell.names.meta}{quoted "name" of a meta.data slot to use for naming the columns instead of using the raw cell/sample names.}
 
 \item{assay, slot}{single strings or integer that set which expression data to use. See \code{\link{gene}} for more information about how defaults for these are filled in when not provided.}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 
 \item{heatmap.colors}{the colors to use within the heatmap when (default setting) \code{scaled.to.max} is set to \code{FALSE}.
 Default is a ramp from navy to white to red with 50 slices.}

--- a/man/dittoHex.Rd
+++ b/man/dittoHex.Rd
@@ -24,6 +24,7 @@ dittoDimHex(
   assay = .default_assay(object),
   slot = .default_slot(object),
   adjustment = NULL,
+  swap.rownames = NULL,
   assay.extra = assay,
   slot.extra = slot,
   adjustment.extra = adjustment,
@@ -92,6 +93,7 @@ dittoScatterHex(
   assay.extra = .default_assay(object),
   slot.extra = .default_slot(object),
   adjustment.extra = NULL,
+  swap.rownames = NULL,
   min.density = NA,
   max.density = NA,
   min.color = "#F0E442",
@@ -180,6 +182,8 @@ Useful for making custom alterations \emph{after} dittoSeq plot generation.}
 \item{split.nrow, split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
 
 \item{assay, slot, adjustment, assay.x, assay.y, assay.color, assay.extra, slot.x, slot.y, slot.color, slot.extra, adjustment.x, adjustment.y, adjustment.color, adjustment.extra}{assay, slot, and adjustment set which data to use when the axes, coloring, or \code{extra.vars} are based on expression/counts data. See \code{\link{gene}} for additional information.}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 
 \item{show.axes.numbers}{Logical which controls whether the axes values should be displayed.}
 

--- a/man/dittoPlot.Rd
+++ b/man/dittoPlot.Rd
@@ -20,6 +20,7 @@ dittoPlot(
   assay = .default_assay(object),
   slot = .default_slot(object),
   adjustment = NULL,
+  swap.rownames = NULL,
   do.hover = FALSE,
   hover.data = var,
   color.panel = dittoColors(),
@@ -109,6 +110,8 @@ See details section for more info.}
 \item{"z-score": scaled with the scale() function to produce a relative-to-mean z-score representation}
 \item{"relative.to.max": divided by the maximum expression value to give percent of max values between [0,1]}
 }}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 
 \item{do.hover}{Logical. Default = \code{FALSE}.
 If set to \code{TRUE} (and if there is a "jitter" in \code{plots}): object will be converted to a ggplotly object so that data about individual cells will be displayed when you hover your cursor over the jitter points,

--- a/man/dittoPlotVarsAcrossGroups.Rd
+++ b/man/dittoPlotVarsAcrossGroups.Rd
@@ -15,6 +15,7 @@ dittoPlotVarsAcrossGroups(
   assay = .default_assay(object),
   slot = .default_slot(object),
   adjustment = "z-score",
+  swap.rownames = NULL,
   do.hover = FALSE,
   main = NULL,
   sub = NULL,
@@ -84,6 +85,8 @@ See details section for more info.}
 \item{NULL: no adjustment, the normal method for all other ditto expression plotting}
 \item{"relative.to.max": divided by the maximum expression value to give percent of max values between [0,1]}
 }}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 
 \item{do.hover}{Logical. Default = \code{FALSE}.
 If set to \code{TRUE} (and if there is a "jitter" in \code{plots}): the object will be converted to a plotly object in which underlying data about individual points will be displayed when you hover your cursor over them.

--- a/man/dittoScatterPlot.Rd
+++ b/man/dittoScatterPlot.Rd
@@ -32,6 +32,7 @@ dittoScatterPlot(
   assay.extra = .default_assay(object),
   slot.extra = .default_slot(object),
   adjustment.extra = NULL,
+  swap.rownames = NULL,
   shape.panel = c(16, 15, 17, 23, 25, 8),
   rename.color.groups = NULL,
   rename.shape.groups = NULL,
@@ -122,6 +123,8 @@ Great for when you have MANY overlapping points, this sets how solid the points 
 \item{split.nrow, split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
 
 \item{assay.x, assay.y, assay.color, assay.extra, slot.x, slot.y, slot.color, slot.extra, adjustment.x, adjustment.y, adjustment.color, adjustment.extra}{assay, slot, and adjustment set which data to use when the axes, coloring, or \code{extra.vars} are based on expression/counts data. See \code{\link{gene}} for additional information.}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 
 \item{shape.panel}{Vector of integers corresponding to ggplot shapes which sets what shapes to use.
 When discrete groupings are supplied by \code{shape.by}, this sets the panel of shapes.

--- a/man/gene.Rd
+++ b/man/gene.Rd
@@ -10,7 +10,8 @@ gene(
   assay = .default_assay(object),
   slot = .default_slot(object),
   adjustment = NULL,
-  adj.fxn = NULL
+  adj.fxn = NULL,
+  swap.rownames = NULL
 )
 }
 \arguments{
@@ -36,6 +37,8 @@ When not provided, these typical defaults for the provided \code{object} class a
 \item{adj.fxn}{A function which takes a vector (of metadata values) and returns a vector of the same length.
 
 For example, \code{function(x) \{log2(x)\}} or \code{as.factor}}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 }
 \value{
 Returns the expression values of a gene for all cells/samples.

--- a/man/getGenes.Rd
+++ b/man/getGenes.Rd
@@ -4,12 +4,14 @@
 \alias{getGenes}
 \title{Returns the names of all genes of a target object.}
 \usage{
-getGenes(object, assay = .default_assay(object))
+getGenes(object, assay = .default_assay(object), swap.rownames = NULL)
 }
 \arguments{
 \item{object}{A Seurat, SingleCellExperiment, or SummarizedExperiment object.}
 
-\item{assay}{single string or integer that sets which set of seq data inside the object to check.}
+\item{assay}{Single string or integer that sets which set of seq data inside the object to check.}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 }
 \value{
 A string vector, returns the names of all genes of the \code{object} for the requested \code{assay}.

--- a/man/isGene.Rd
+++ b/man/isGene.Rd
@@ -4,7 +4,13 @@
 \alias{isGene}
 \title{Tests if input is the name of a gene in a target object.}
 \usage{
-isGene(test, object, assay = .default_assay(object), return.values = FALSE)
+isGene(
+  test,
+  object,
+  assay = .default_assay(object),
+  return.values = FALSE,
+  swap.rownames = NULL
+)
 }
 \arguments{
 \item{test}{String or vector of strings, the "potential.gene.name"(s) to check for.}
@@ -15,6 +21,8 @@ isGene(test, object, assay = .default_assay(object), return.values = FALSE)
 
 \item{return.values}{Logical which sets whether the function returns a logical \code{TRUE}/\code{FALSE} versus the \code{TRUE} \code{test} values . Default = \code{FALSE}
 REQUIRED, unless '\code{DEFAULT <- "object"}' has been run.}
+
+\item{swap.rownames}{String. For SummarizeedExperiment or SingleCellExperiment objects, the column name of rowData(object) to be used to identify features instead of rownames(object).}
 }
 \value{
 Returns a logical vector indicating whether each instance in \code{test} is a rowname within the requested \code{assay} of the \code{object}.

--- a/man/multi_dittoDimPlotVaryCells.Rd
+++ b/man/multi_dittoDimPlotVaryCells.Rd
@@ -28,7 +28,8 @@ multi_dittoDimPlotVaryCells(
   color.panel = dittoColors(),
   colors = seq_along(color.panel),
   data.out = FALSE,
-  do.hover = FALSE
+  do.hover = FALSE,
+  swap.rownames = NULL
 )
 }
 \arguments{
@@ -62,7 +63,7 @@ Discrete or continuous data both work.}
 
 \item{OUT.List}{Deprecated. Use \code{list.out}}
 
-\item{..., color.panel, colors, min, max, assay, slot, adjustment, data.out, do.hover}{additional parameters passed to \code{\link{dittoDimPlot}}.
+\item{..., color.panel, colors, min, max, assay, slot, adjustment, data.out, do.hover, swap.rownames}{additional parameters passed to \code{\link{dittoDimPlot}}.
 
 All parameters of \code{\link{dittoDimPlot}} can be utilized and adjusted except for \code{cells.use}, \code{main}, and \code{legend.show} which are handled with alternative methods here.
 A few suggestions: \code{reduction.use} for setting which dimensionality reduction space to use.

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -45,7 +45,10 @@ sce <- SingleCellExperiment(
                         age = age,
                         score = score,
                         score2 = score2,
-                        score3 = score3)
+                        score3 = score3),
+    rowData = DataFrame(
+        rows = rownames(exp),
+        symbol = paste(rownames(exp), "symb", sep = "_"))
 )
 
 # Remove the unneeded external data

--- a/tests/testthat/test-DimPlot.R
+++ b/tests/testthat/test-DimPlot.R
@@ -538,3 +538,10 @@ test_that("dittoDimPlot added features work with double-metadata faceting", {
                     c(5:10,9:5,6:10))))),
         NA)
 })
+
+test_that("dittoDimPlot swap.rownames works", {
+    expect_s3_class(
+        dittoDimPlot(sce, "gene1_symb", swap.rownames = "symbol"),
+        "ggplot")
+})
+

--- a/tests/testthat/test-DotPlot.R
+++ b/tests/testthat/test-DotPlot.R
@@ -226,3 +226,23 @@ test_that("dittoDotPlot assay, slot, adjustment work", {
     expect_true(all(
         d_raw$data$color >= d_log$data$color))
 })
+
+test_that("dittoDotPlot swap.rownames works", {
+    
+    swap_genes <- paste(genes, "symb", sep = "_")
+    
+    no_swap <- dittoDotPlot(sce, genes, disc, data.out = TRUE)
+    swap <- dittoDotPlot(sce, swap_genes, disc, data.out = TRUE,
+                         swap.rownames = "symbol")
+    
+    expect_equivalent(no_swap$data$color, swap$data$color)
+    expect_equivalent(swap$data$var,
+                      factor(paste(no_swap$data$var, "symb", sep = "_")))
+    
+    expect_s3_class(
+        no_swap$p,
+        "ggplot")
+    expect_s3_class(
+        swap$p,
+        "ggplot")
+})

--- a/tests/testthat/test-Heatmap.R
+++ b/tests/testthat/test-Heatmap.R
@@ -396,3 +396,18 @@ test_that("scale and border_color pheatmap inputs function as expected", {
             border_color = "red"),
         "pheatmap")
 })
+
+test_that("dittoHeatmap swap.rownames works", {
+    swap_genes <- paste(genes, "symb", sep = "_")
+    
+    expect_s3_class(
+        dittoHeatmap(genes = swap_genes, object = sce, swap.rownames = "symbol"),
+        "pheatmap")
+    expect_equivalent(
+        rownames(
+            dittoHeatmap(
+                genes = swap_genes, object = sce, swap.rownames = "symbol",
+                data.out = TRUE
+            )$mat),
+        swap_genes)
+})

--- a/tests/testthat/test-Hex.R
+++ b/tests/testthat/test-Hex.R
@@ -395,3 +395,13 @@ test_that("dittoScatterHex gene display can utilize different data.types (exclud
     expect_equal(
         max(p$data$Y), 1)
 })
+
+test_that("dittoScatterHex swap.rownames works", {
+    expect_s3_class(
+        dittoDimHex(sce, "gene1_symb", swap.rownames = "symbol"),
+        "ggplot")
+    expect_s3_class(
+        dittoScatterHex(sce, "gene1_symb", "gene2_symb", "gene3_symb",
+            swap.rownames = "symbol"),
+        "ggplot")
+})

--- a/tests/testthat/test-Plot.R
+++ b/tests/testthat/test-Plot.R
@@ -398,3 +398,9 @@ test_that("dittoPlot with and without jitter rasterization produces identical pl
             plots = c("vlnplot", "jitter")),
         "ggplot")
 })
+
+test_that("dittoPlot swap.rownames works", {
+    expect_s3_class(
+        dittoPlot(sce, "gene1_symb", grp, swap.rownames = "symbol"),
+        "ggplot")
+})

--- a/tests/testthat/test-PlotVarsAcrossGroups.R
+++ b/tests/testthat/test-PlotVarsAcrossGroups.R
@@ -313,3 +313,24 @@ test_that("dittoPlotVarsAcrossGroups with and without jitter rasterization produ
             plots = c("vlnplot", "boxplot", "jitter")),
         "ggplot")
 })
+
+test_that("dittoPlotVarsAcrossGroups swap.rownames works", {
+    
+    swap_genes <- paste(genes, "symb", sep = "_")
+    
+    no_swap <- dittoPlotVarsAcrossGroups(sce, genes, grp, data.out = TRUE)
+    swap <- dittoPlotVarsAcrossGroups(
+        sce, swap_genes, grp, data.out = TRUE,
+        swap.rownames = "symbol")
+    
+    expect_equivalent(no_swap$data$color, swap$data$color)
+    expect_equivalent(swap$data$var,
+                      paste(no_swap$data$var, "symb", sep = "_"))
+    
+    expect_s3_class(
+        no_swap$p,
+        "ggplot")
+    expect_s3_class(
+        swap$p,
+        "ggplot")
+})

--- a/tests/testthat/test-getters.R
+++ b/tests/testthat/test-getters.R
@@ -92,6 +92,24 @@ test_that("gene gives error when given a non-meta", {
         "is not a gene of 'object'", fixed = TRUE)
 })
 
+test_that("gene, isGene, and getGenes work with swap.rownames",{
+    
+    swap_genes <- paste(rownames(sce), "symb", sep = "_")
+    
+    expect_equal(
+        getGenes(sce, swap.rownames = "symbol"),
+        swap_genes)
+    
+    expect_true(
+        isGene("gene1_symb", sce, swap.rownames = "symbol"))
+    
+    expect_type(
+        gene("gene1_symb", sce, swap.rownames = "symbol"),
+        "double"
+    )
+    
+})
+
 test_that("getReductions works for Seurat and SCE", {
     expect_type(reductions <- getReductions(seurat),
         "character")
@@ -138,7 +156,3 @@ test_that(".which_cells errors when logical 'cells.use' is the wrong length", {
         "'cells.use' length must equal the number of cells/samples in 'object' when given in logical form",
         fixed = TRUE)
 })
-
-
-
-

--- a/tests/testthat/test-multi_VaryCells.R
+++ b/tests/testthat/test-multi_VaryCells.R
@@ -100,3 +100,10 @@ test_that("VaryCells tells that 'main' is ignored.", {
             main = "HELLO"),
         "'main' ignored", fixed = TRUE)
 })
+
+test_that("VaryCells swap.rownames works", {
+    expect_s3_class(
+        multi_dittoDimPlotVaryCells(
+            sce, "gene1_symb", grp, swap.rownames = "symbol"),
+        "gtable")
+})


### PR DESCRIPTION
- Adds a `swap.rownames` input to all visualizations that can target feature data, and to the `gene()`, `isGene()`, and `getGenes()` helper functions as well.