### PR TITLE
Show all 'other' cells in background of scatter plot facets

### DIFF
--- a/R/DittoDimPlot.R
+++ b/R/DittoDimPlot.R
@@ -29,7 +29,7 @@
 #' See \url{https://ggplot2.tidyverse.org/reference/ggtheme.html} for other options and ideas.
 #' @param show.grid.lines Logical which sets whether gridlines of the plot should be shown.
 #' They are removed when set to FALSE.
-#' Default = TRUE for umap and tsne \code{reduction.use}, FALSE otherwise.
+#' Default = FALSE for umap and tsne \code{reduction.use}, TRUE otherwise.
 #' @param color.panel String vector which sets the colors to draw from. \code{dittoColors()} by default, see \code{\link{dittoColors}} for contents.
 #' @param colors Integer vector, the indexes / order, of colors from color.panel to actually use.
 #'
@@ -45,6 +45,7 @@
 #' When 1 metadata is named, shape control can be achieved with \code{split.nrow} and \code{split.ncol}
 #'
 #' @param split.nrow,split.ncol Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.
+#' @param split.show.all.others Logical which sets whether gray "others" cells of facets should include all cells of other facets (\code{TRUE}) versus just cells left out by \code{cell.use} (\code{FALSE}).
 #' @param extra.vars String vector providing names of any extra metadata to be stashed in the dataframe supplied to \code{ggplot(data)}.
 #'
 #' Useful for making custom splitting/faceting or other additional alterations \emph{after} dittoSeq plot generation.
@@ -257,6 +258,8 @@ dittoDimPlot <- function(
     shape.by = NULL,
     split.by = NULL,
     extra.vars = NULL,
+    show.others = TRUE,
+    split.show.all.others = TRUE,
     split.nrow = NULL,
     split.ncol = NULL,
     assay = .default_assay(object),
@@ -266,9 +269,6 @@ dittoDimPlot <- function(
     color.panel = dittoColors(),
     colors = seq_along(color.panel),
     shape.panel = c(16,15,17,23,25,8),
-    show.others = TRUE,
-    show.axes.numbers = TRUE,
-    show.grid.lines = if (is.character(reduction.use)) { !grepl("umap|tsne", tolower(reduction.use)) } else {TRUE},
     min.color = "#F0E442",
     max.color = "#0072B2",
     min = NULL,
@@ -281,6 +281,8 @@ dittoDimPlot <- function(
     rename.var.groups = NULL,
     rename.shape.groups = NULL,
     theme = theme_bw(),
+    show.axes.numbers = TRUE,
+    show.grid.lines = if (is.character(reduction.use)) { !grepl("umap|tsne", tolower(reduction.use)) } else {TRUE},
     do.letter = FALSE,
     do.ellipse = FALSE,
     do.label = FALSE,
@@ -339,8 +341,8 @@ dittoDimPlot <- function(
     # Make dataframes and plot
     p.df <- dittoScatterPlot(
         object, xdat$embeddings, ydat$embeddings, var, shape.by, split.by,
-        extra.vars, cells.use,
-        show.others, size, opacity, color.panel, colors,
+        extra.vars, cells.use, show.others, split.show.all.others,
+        size, opacity, color.panel, colors,
         split.nrow, split.ncol, NA, NA, NA, NA, NA, NA,
         assay, slot, adjustment, assay, slot, adjustment, swap.rownames,
         shape.panel, rename.var.groups, rename.shape.groups,

--- a/R/DittoScatterPlot.R
+++ b/R/DittoScatterPlot.R
@@ -170,6 +170,7 @@ dittoScatterPlot <- function(
     extra.vars = NULL,
     cells.use = NULL,
     show.others = FALSE,
+    split.show.all.others = TRUE,
     size = 1,
     opacity = 1,
     color.panel = dittoColors(),
@@ -276,7 +277,8 @@ dittoScatterPlot <- function(
         xlab, ylab, main, sub, theme,
         legend.show, legend.color.title, legend.color.size,
         legend.color.breaks, legend.color.breaks.labels, legend.shape.title,
-        legend.shape.size, do.raster, raster.dpi, split.by)
+        legend.shape.size, do.raster, raster.dpi,
+        split.by, split.show.all.others)
 
     ### Add extra features
     if (!is.null(split.by)) {
@@ -348,7 +350,8 @@ dittoScatterPlot <- function(
     legend.shape.size,
     do.raster,
     raster.dpi,
-    split.by
+    split.by,
+    split.show.all.others
 ) {
     
     ### Set up plotting
@@ -399,7 +402,7 @@ dittoScatterPlot <- function(
     ### Add data
     # Others_data
     if (show.others) {
-        if (!is.null(split.by)) {
+        if (!is.null(split.by) && split.show.all.others) {
             Others_data <- .rep_all_data_per_facet(
                 Target_data, Others_data, split.by)
         }

--- a/R/DittoScatterPlot.R
+++ b/R/DittoScatterPlot.R
@@ -473,3 +473,63 @@ dittoScatterPlot <- function(
         )
     )
 }
+
+.scatter_data_gather <- function(
+    object,
+    cells.use,
+    x.var,
+    y.var,
+    color.var,
+    shape.by,
+    split.by,
+    extra.vars,
+    assay.x,
+    slot.x,
+    adjustment.x,
+    assay.y,
+    slot.y,
+    adjustment.y,
+    assay.color,
+    slot.color,
+    adjustment.color,
+    assay.extra,
+    slot.extra,
+    adjustment.extra,
+    swap.rownames = NULL,
+    do.hover = FALSE,
+    hover.data = NULL,
+    hover.assay = NULL,
+    hover.slot = NULL,
+    hover.adjustment = NULL,
+    rename.color.groups = NULL,
+    rename.shape.groups = NULL
+    ) {
+
+    all.cells <- .all_cells(object)
+    object <- .swap_rownames(object, swap.rownames)
+    
+    # Make dataframe
+    vars <- list(x.var, y.var, color.var, shape.by)
+    names <- list("X", "Y", "color", "shape")
+    assays <- list(assay.x, assay.y, assay.color, NA)
+    slots <- list(slot.x, slot.y, slot.color, NA)
+    adjustments <- list(adjustment.x, adjustment.y, adjustment.color, NA)
+    relabels <- list(NULL, NULL, rename.color.groups, rename.shape.groups)
+
+    dat <- data.frame(row.names = all.cells)
+    for (i in seq_along(vars)) {
+        dat <- .add_by_cell(dat, vars[[i]], names[[i]], object, assays[[i]],
+            slots[[i]], adjustments[[i]], NULL, relabels[[i]])
+    }
+
+    extra.vars <- unique(c(split.by, extra.vars))
+    dat <- .add_by_cell(dat, extra.vars, extra.vars, object, assay.extra,
+        slot.extra, adjustment.extra, mult = TRUE)
+
+    if (do.hover) {
+        dat$hover.string <- .make_hover_strings_from_vars(
+            hover.data, object, hover.assay, hover.slot, hover.adjustment)
+    }
+    
+    dat
+}

--- a/R/dittoDotPlot.R
+++ b/R/dittoDotPlot.R
@@ -361,7 +361,8 @@ dittoDotPlot <- function(
                 }
                 
                 new_data
-            })
+            }
+        )
     )
 
     if (do.hover) {

--- a/R/dittoHex.R
+++ b/R/dittoHex.R
@@ -529,66 +529,6 @@ dittoScatterHex <- function(
     p
 }
 
-.scatter_data_gather <- function(
-    object,
-    cells.use,
-    x.var,
-    y.var,
-    color.var,
-    shape.by,
-    split.by,
-    extra.vars,
-    assay.x,
-    slot.x,
-    adjustment.x,
-    assay.y,
-    slot.y,
-    adjustment.y,
-    assay.color,
-    slot.color,
-    adjustment.color,
-    assay.extra,
-    slot.extra,
-    adjustment.extra,
-    swap.rownames = NULL,
-    do.hover = FALSE,
-    hover.data = NULL,
-    hover.assay = NULL,
-    hover.slot = NULL,
-    hover.adjustment = NULL,
-    rename.color.groups = NULL,
-    rename.shape.groups = NULL
-    ) {
-
-    all.cells <- .all_cells(object)
-    object <- .swap_rownames(object, swap.rownames)
-    
-    # Make dataframe
-    vars <- list(x.var, y.var, color.var, shape.by)
-    names <- list("X", "Y", "color", "shape")
-    assays <- list(assay.x, assay.y, assay.color, NA)
-    slots <- list(slot.x, slot.y, slot.color, NA)
-    adjustments <- list(adjustment.x, adjustment.y, adjustment.color, NA)
-    relabels <- list(NULL, NULL, rename.color.groups, rename.shape.groups)
-
-    dat <- data.frame(row.names = all.cells)
-    for (i in seq_along(vars)) {
-        dat <- .add_by_cell(dat, vars[[i]], names[[i]], object, assays[[i]],
-            slots[[i]], adjustments[[i]], NULL, relabels[[i]])
-    }
-
-    extra.vars <- unique(c(split.by, extra.vars))
-    dat <- .add_by_cell(dat, extra.vars, extra.vars, object, assay.extra,
-        slot.extra, adjustment.extra, mult = TRUE)
-
-    if (do.hover) {
-        dat$hover.string <- .make_hover_strings_from_vars(
-            hover.data, object, hover.assay, hover.slot, hover.adjustment)
-    }
-    
-    dat
-}
-
 .check_color.method <- function(color.method, discrete) {
     
     valid <- FALSE

--- a/man/dittoDimPlot.Rd
+++ b/man/dittoDimPlot.Rd
@@ -16,6 +16,8 @@ dittoDimPlot(
   shape.by = NULL,
   split.by = NULL,
   extra.vars = NULL,
+  show.others = TRUE,
+  split.show.all.others = TRUE,
   split.nrow = NULL,
   split.ncol = NULL,
   assay = .default_assay(object),
@@ -25,10 +27,6 @@ dittoDimPlot(
   color.panel = dittoColors(),
   colors = seq_along(color.panel),
   shape.panel = c(16, 15, 17, 23, 25, 8),
-  show.others = TRUE,
-  show.axes.numbers = TRUE,
-  show.grid.lines = if (is.character(reduction.use)) {     !grepl("umap|tsne",
-    tolower(reduction.use)) } else {     TRUE },
   min.color = "#F0E442",
   max.color = "#0072B2",
   min = NULL,
@@ -41,6 +39,9 @@ dittoDimPlot(
   rename.var.groups = NULL,
   rename.shape.groups = NULL,
   theme = theme_bw(),
+  show.axes.numbers = TRUE,
+  show.grid.lines = if (is.character(reduction.use)) {     !grepl("umap|tsne",
+    tolower(reduction.use)) } else {     TRUE },
   do.letter = FALSE,
   do.ellipse = FALSE,
   do.label = FALSE,
@@ -118,6 +119,10 @@ When 1 metadata is named, shape control can be achieved with \code{split.nrow} a
 
 Useful for making custom splitting/faceting or other additional alterations \emph{after} dittoSeq plot generation.}
 
+\item{show.others}{Logical. Whether other cells should be shown in the background in light gray. Default = TRUE.}
+
+\item{split.show.all.others}{Logical which sets whether gray "others" cells of facets should include all cells of other facets (\code{TRUE}) versus just cells left out by \code{cell.use} (\code{FALSE}).}
+
 \item{split.nrow, split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
 
 \item{assay, slot}{single strings or integer that set which data to use when plotting gene expression.
@@ -145,14 +150,6 @@ Default is a set of 6, \code{c(16,15,17,23,25,8)}, the first being a simple, sol
 Note: Unfortunately, shapes can be hard to see when points are on top of each other & they are more slowly processed by the brain.
 For these reasons, even as a color blind person myself writing this code, I recommend use of colors for variables with many discrete values.}
 
-\item{show.others}{Logical. Whether other cells should be shown in the background in light gray. Default = TRUE.}
-
-\item{show.axes.numbers}{Logical which controls whether the axes values should be displayed.}
-
-\item{show.grid.lines}{Logical which sets whether gridlines of the plot should be shown.
-They are removed when set to FALSE.
-Default = TRUE for umap and tsne \code{reduction.use}, FALSE otherwise.}
-
 \item{min.color}{color for lowest values of \code{var}/\code{min}.  Default = yellow}
 
 \item{max.color}{color for highest values of \code{var}/\code{max}.  Default = blue}
@@ -179,6 +176,12 @@ To remove, set to \code{NULL}.}
 \item{theme}{A ggplot theme which will be applied before dittoSeq adjustments.
 Default = \code{theme_bw()}.
 See \url{https://ggplot2.tidyverse.org/reference/ggtheme.html} for other options and ideas.}
+
+\item{show.axes.numbers}{Logical which controls whether the axes values should be displayed.}
+
+\item{show.grid.lines}{Logical which sets whether gridlines of the plot should be shown.
+They are removed when set to FALSE.
+Default = FALSE for umap and tsne \code{reduction.use}, TRUE otherwise.}
 
 \item{do.letter}{Logical which sets whether letters should be added on top of the colored dots. For extended colorblindness compatibility.
 NOTE: \code{do.letter} is ignored if \code{do.hover = TRUE} or \code{shape.by} is provided a metadata because

--- a/man/dittoHex.Rd
+++ b/man/dittoHex.Rd
@@ -189,7 +189,7 @@ Useful for making custom alterations \emph{after} dittoSeq plot generation.}
 
 \item{show.grid.lines}{Logical which sets whether gridlines of the plot should be shown.
 They are removed when set to FALSE.
-Default = TRUE for umap and tsne \code{reduction.use}, FALSE otherwise.}
+Default = FALSE for umap and tsne \code{reduction.use}, TRUE otherwise.}
 
 \item{main}{String, sets the plot title. The default title is either "Density", \code{color.var}, or NULL, depending on the identity of \code{color.var}.
 To remove, set to \code{NULL}.}

--- a/man/dittoScatterPlot.Rd
+++ b/man/dittoScatterPlot.Rd
@@ -14,6 +14,7 @@ dittoScatterPlot(
   extra.vars = NULL,
   cells.use = NULL,
   show.others = FALSE,
+  split.show.all.others = TRUE,
   size = 1,
   opacity = 1,
   color.panel = dittoColors(),
@@ -108,6 +109,8 @@ Useful for making custom alterations \emph{after} dittoSeq plot generation.}
 Alternatively, a Logical vector, the same length as the number of cells in the object, which sets which cells to include.}
 
 \item{show.others}{Logical. FALSE by default, whether other cells should be shown in the background in light gray.}
+
+\item{split.show.all.others}{Logical which sets whether gray "others" cells of facets should include all cells of other facets (\code{TRUE}) versus just cells left out by \code{cell.use} (\code{FALSE}).}
 
 \item{size}{Number which sets the size of data points. Default = 1.}
 

--- a/tests/testthat/test-DimPlot.R
+++ b/tests/testthat/test-DimPlot.R
@@ -443,12 +443,40 @@ test_that("dittoDimPlot can be faceted with split.by (1 or 2 vars)", {
             disc, object=seurat,
             split.by = c(disc2,disc)),
         "ggplot")
-    # Works with cells.use (should have grey cells)
+})
+
+test_that("dittoDimPlot faceting and cell.use and split.show.all.others work together", {
+    # MANUAL: Works with cells.use (should have grey cells)
+    expect_s3_class(
+        dittoDimPlot(
+            disc, object=seurat,
+            split.by = c(disc2),
+            cells.use = cells.logical,
+            split.show.all.others = FALSE),
+        "ggplot")
     expect_s3_class(
         dittoDimPlot(
             disc, object=seurat,
             split.by = c(disc2,disc),
-            cells.use = cells.logical),
+            cells.use = cells.logical,
+            split.show.all.others = FALSE),
+        "ggplot")
+    
+    # MANUAL: Works with split.show.all.others on (should even more grey cells)
+    expect_s3_class(
+        dittoDimPlot(
+            disc, object=seurat,
+            split.by = c(disc2,disc),
+            cells.use = cells.logical,
+            split.show.all.others = TRUE),
+        "ggplot")
+    # MANUAL: Works with split.show.all.others on (should even more grey cells)
+    expect_s3_class(
+        dittoDimPlot(
+            disc, object=seurat,
+            split.by = c(disc2,disc),
+            cells.use = cells.logical,
+            split.show.all.others = TRUE),
         "ggplot")
 })
 
@@ -457,25 +485,29 @@ test_that("dittoDimPlot added features work with single-metadata faceting", {
         print(dittoDimPlot(
             disc, object=seurat,
             split.by = disc2,
-            do.label = TRUE)),
+            do.label = TRUE,
+            split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
             disc, object=seurat,
             split.by = disc2,
-            do.ellipse = TRUE)),
+            do.ellipse = TRUE,
+            split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
             disc, object=seurat,
             split.by = disc2,
-            do.letter = TRUE)),
+            do.letter = TRUE,
+            split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
             disc, object=seurat,
             split.by = disc2,
-            do.contour = TRUE)),
+            do.contour = TRUE,
+            split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
@@ -483,7 +515,8 @@ test_that("dittoDimPlot added features work with single-metadata faceting", {
             split.by = disc2,
             add.trajectory.lineages = list(
                     c("C","A")),
-            trajectory.cluster.meta = disc)),
+            trajectory.cluster.meta = disc,
+            split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
@@ -495,7 +528,8 @@ test_that("dittoDimPlot added features work with single-metadata faceting", {
                     c(-20,-10,0)),
                 data.frame(
                     c(5:20),
-                    c(5:10,9:5,6:10))))),
+                    c(5:10,9:5,6:10))),
+            split.show.all.others = FALSE)),
         NA)
 })
 
@@ -504,19 +538,22 @@ test_that("dittoDimPlot added features work with double-metadata faceting", {
         print(dittoDimPlot(
             disc, object=seurat,
             split.by = c(disc2,disc),
-            do.label = TRUE)),
+            do.label = TRUE,
+            split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
             disc, object=seurat,
             split.by = c(disc2,disc),
-            do.ellipse = TRUE)),
+            do.ellipse = TRUE,
+            split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
             disc, object=seurat,
             split.by = c(disc2,disc),
-            do.letter = TRUE)),
+            do.letter = TRUE,
+            split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
@@ -524,7 +561,8 @@ test_that("dittoDimPlot added features work with double-metadata faceting", {
             split.by = c(disc2,disc),
             add.trajectory.lineages = list(
                     c("C","A")),
-            trajectory.cluster.meta = disc)),
+            trajectory.cluster.meta = disc,
+            split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
@@ -536,7 +574,8 @@ test_that("dittoDimPlot added features work with double-metadata faceting", {
                     c(-20,-10,0)),
                 data.frame(
                     c(5:20),
-                    c(5:10,9:5,6:10))))),
+                    c(5:10,9:5,6:10))),
+            split.show.all.others = FALSE)),
         NA)
 })
 

--- a/tests/testthat/test-DimPlot.R
+++ b/tests/testthat/test-DimPlot.R
@@ -332,11 +332,11 @@ test_that("dittoDimPlot can remove axes numbers", {
 
 test_that("dittoDimPlot plotting order can be ordered by the data", {
     out <- dittoDimPlot(disc, object=seurat, data.out = TRUE, size = 10, order = "decreasing")
-    ### Manual Check: Orange aalways in front
+    ### Manual Check: Orange always in front
     expect_s3_class(
         out$p,
         "ggplot")
-    ### Manual Check: Dark blue aalways in front
+    ### Manual Check: Dark blue always in front
     expect_equal(
         out$Target_data$color,
         rev(


### PR DESCRIPTION
By ensuring Others_data becomes a repeat of all_data for every facet.

To Do:

- [x] decide if should add `split.show.all.others` input for turning off this new behavior. (Seems useful situationally in conjunction with `cells.use`!)
- [x]  If yes:
    - [x] add docs
    - [x] add a test