### PR TITLE
Reduce Seurat code reliance in build / check materials

### DIFF
--- a/R/meta-getters.R
+++ b/R/meta-getters.R
@@ -174,11 +174,11 @@ meta <- function(meta, object,
 #'
 #' @param meta quoted "meta.data.slot" name = REQUIRED. the meta.data slot whose potential values should be retrieved.
 #' @param object A Seurat, SingleCellExperiment, or SummarizedExperiment object.
-#' @param used.only TRUE by default, whether unused levels of already
+#' @param used.only TRUE by default, for target metadata that are factors, whether levels nonexistent in the target data should be ignored.
 #' @param cells.use String vector of cells'/samples' names OR an integer vector specifying the indices of cells/samples which should be included.
 #' 
 #' Alternatively, a Logical vector, the same length as the number of cells in the object, which sets which cells to include.
-#' @return Returns the distinct values of a metadata slot (factor or not) among to all cells/samples, or for a subset of cells/samples.
+#' @return String vector, the distinct values of a metadata slot (factor or not) among all cells/samples, or for a subset of cells/samples.
 #' (Alternatively, returns the distinct values of clustering if \code{meta = "ident"} and the object is a \code{Seurat} object).
 #' @seealso
 #' \code{\link{meta}} for returning an entire metadata slots of an \code{object}, not just the potential levels

--- a/README.md
+++ b/README.md
@@ -125,11 +125,10 @@ Because often users will be familiar with Seurat already, so this may be 90% of 
   
   See reference below for the equivalent names of major inputs
   
-  For input names Seurat has had some inconsistency compared to its past. dittoSeq
-  actually drew some of its parameter names from previous Seurat-equivalents in
-  order to ease cross-conversion, but alas... I will NOT break peoples' code
-  just to follow another package's changes (and especially not just for the
-  purpose of "We like this name better now."). Instead, dittoSeq input names are
+  Seurat has had inconsistency in input names from version to version. dittoSeq
+  drew some of its parameter names from previous Seurat-equivalents to ease
+  cross-conversion, but continuing to blindly copy their parameter standards will
+  break people's already existing code. Instead, dittoSeq input names are
   guaranteed to remain consistent across versions, unless a change is required for
   useful feature additions.
   

--- a/README.md
+++ b/README.md
@@ -94,6 +94,65 @@ if (!requireNamespace("devtools", quietly = TRUE))
 devtools::install_github("dtm2451/dittoSeq")
 ```
 
+# Quick Reference: Seurat <=> dittoSeq
+
+Because often users will be familiar with Seurat already, so this may be 90% of what you may need!
+
+<details>
+
+  <summary>Click to expand</summary>
+
+  As of May 25th, 2021, Seurat-v4.0.2 & dittoSeq v1.4.1
+  
+  **Functions**
+  
+  Seurat Viz Function(s) | dittoSeq Equivalent(s)
+  --- | ---
+  DimPlot/ (I)FeaturePlot / UMAPPlot / etc. | dittoDimPlot / multi_dittoDimPlot
+  VlnPlot / RidgePlot | dittoPlot / multi_dittoPlot
+  DotPlot | dittoDotPlot
+  FeatureScatter / GenePlot | dittoScatterPlot
+  DoHeatmap | dittoHeatmap*
+  [No Seurat Equivalent] | dittoBarPlot / dittoFreqPlot
+  [No Seurat Equivalent] | dittoDimHex / dittoScatterHex
+  [No Seurat Equivalent] | dittoPlotVarsAcrossGroups
+  SpatialDimPlot, SpatialFeaturePlot, etc. | dittoSpatial (coming soon!)
+  
+  *Not all dittoSeq features exist in Seurat counterparts, and occasionally the
+  same is true in the reverse.
+  
+  **Inputs**
+  
+  See reference below for the equivalent names of major inputs
+  
+  For input names Seurat has had some inconsistency compared to its past. dittoSeq
+  actually drew some of its parameter names from previous Seurat-equivalents in
+  order to ease cross-conversion, but alas... I will NOT break peoples' code
+  just to follow another package's changes (and especially not just for the
+  purpose of "We like this name better now."). Instead, dittoSeq input names are
+  guaranteed to remain consistent across versions, unless a change is required for
+  useful feature additions.
+  
+  Seurat Viz Input(s) | dittoSeq Equivalents
+  --- | ---
+  `object` | SAME
+  `features` | `var` / `vars` (generally the 2nd input, so name not needed!) OR `genes` & `metas` for dittoHeatmap()
+  `cells` (cell subsetting is not always available) | `cells.use` (consistently available)
+  `reduction` & `dims` | `reduction.use` & `dim.1`, `dim.2`
+  `pt.size` | `size` (or `jitter.size`)
+  `group.by` | SAME
+  `split.by` | SAME
+  `shape.by` | SAME and also available in dittoPlot()
+  `fill.by` | `color.by` (can be used to subset `group.by` further!)
+  `assay` / `slot` | SAME
+  `order` = logical | `order` but = "unordered" (default), "increasing", or "decreasing"
+  `cols` | `color.panel` for discrete OR `min.color`, `max.color` for continuous
+  `label` & `label.size` & `repel` | `do.label` & `labels.size` & `labels.repel`
+  `interactive` | `do.hover` = via plotly conversion
+  [Not in Seurat] | `data.out`, `do.raster`, `do.letter`, `do.ellipse`, `add.trajectory.lineages` and others!
+  
+</details>
+
 # Quick Start Guide:
 
 Load in your data, then go!:

--- a/man/metaLevels.Rd
+++ b/man/metaLevels.Rd
@@ -15,10 +15,10 @@ metaLevels(meta, object, cells.use = NULL, used.only = TRUE)
 
 Alternatively, a Logical vector, the same length as the number of cells in the object, which sets which cells to include.}
 
-\item{used.only}{TRUE by default, whether unused levels of already}
+\item{used.only}{TRUE by default, for target metadata that are factors, whether levels nonexistent in the target data should be ignored.}
 }
 \value{
-Returns the distinct values of a metadata slot (factor or not) among to all cells/samples, or for a subset of cells/samples.
+String vector, the distinct values of a metadata slot (factor or not) among all cells/samples, or for a subset of cells/samples.
 (Alternatively, returns the distinct values of clustering if \code{meta = "ident"} and the object is a \code{Seurat} object).
 }
 \description{

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -54,10 +54,6 @@ sce <- SingleCellExperiment(
 # Remove the unneeded external data
 rm(exp,exp.vec,logexp,pca,tsne,l1,l2,clusters,groups,age,score,score2,score3)
 
-# Make a Seurat
-seurat <- suppressWarnings(Seurat::as.Seurat(sce))
-rownames(seurat@meta.data) <- colnames(seurat)
-
 # Manually make bulk
 bulk <- sce
 int_metadata(bulk) <- c(

--- a/tests/testthat/test-BarPlot.R
+++ b/tests/testthat/test-BarPlot.R
@@ -1,30 +1,25 @@
 # Tests for dittoBarPlot function
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-BarPlot.R")
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
+sce$number <- as.numeric(seq_along(colnames(sce)))
 grp1 <- "groups"
 grp2 <- "clusters"
 grp3 <- "age"
-cells.names <- colnames(seurat)[1:40]
+cells.names <- colnames(sce)[1:40]
 cells.logical <- c(rep(TRUE, 40), rep(FALSE,ncells-40))
 
 test_that("dittoBarPlot can quantify clustering of groupings in percent or raw count", {
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3),
+            sce, grp2, group.by = grp3),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3, scale = "count"),
+            sce, grp2, group.by = grp3, scale = "count"),
         "ggplot")
 })
 
-test_that("dittoBarPlot works for SCE", {
-    # SCE
-    expect_s3_class(
-        dittoBarPlot(
-            sce, grp2, group.by = grp3),
-        "ggplot")
+test_that("dittoBarPlot works for bulk", {
     # bulk SCE
     expect_s3_class(
         dittoBarPlot(
@@ -35,20 +30,20 @@ test_that("dittoBarPlot works for SCE", {
 test_that("dittoBarPlots can be subset to show only certain cells/samples with any cells.use method", {
     expect_s3_class(
         {c1 <- dittoBarPlot(
-            seurat, grp2, group.by = grp3,  data.out = TRUE,
+            sce, grp2, group.by = grp3,  data.out = TRUE,
             cells.use = cells.names)
         c1$p},
         "ggplot")
     expect_s3_class(
         {c2 <- dittoBarPlot(
-            seurat, grp2, group.by = grp3, data.out = TRUE,
+            sce, grp2, group.by = grp3, data.out = TRUE,
             cells.use = cells.logical)
         c2$p},
         "ggplot")
     expect_equal(c1$data, c2$data)
     expect_s3_class(
         {c3 <- dittoBarPlot(
-            seurat, grp2, group.by = grp3, data.out = TRUE,
+            sce, grp2, group.by = grp3, data.out = TRUE,
             cells.use = 1:40)
         c3$p},
         "ggplot")
@@ -56,21 +51,21 @@ test_that("dittoBarPlots can be subset to show only certain cells/samples with a
     # And if we remove an entire X grouping...
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
-            cells.use = meta(grp3,seurat)!=0),
+            sce, grp2, group.by = grp3,
+            cells.use = meta(grp3,sce)!=0),
         "ggplot")
     # And if we remove an entire var grouping...
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
-            cells.use = meta(grp2,seurat)!=0),
+            sce, grp2, group.by = grp3,
+            cells.use = meta(grp2,sce)!=0),
         "ggplot")
 })
 
 test_that("dittoBarPlot main legend can be removed", {
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             legend.show = FALSE),
         "ggplot")
 })
@@ -79,17 +74,17 @@ test_that("dittoBarPlots colors can be adjusted", {
     ### Manual check: These two should look the same.
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             color.panel = dittoColors()[5:1]),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             colors = 5:1),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             color.panel = c("red","blue","yellow")),
         "ggplot")
 })
@@ -98,7 +93,7 @@ test_that("dittoBarPlots titles and theme can be adjusted", {
     ### Manual check: All titles should be adjusted.
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             main = "Gotta catch", sub = "em all",
             xlab = "Pokemon", ylab = "Pokedex #s",
             legend.title = "groups"),
@@ -106,7 +101,7 @@ test_that("dittoBarPlots titles and theme can be adjusted", {
     ### Manual check: plot should be boxed
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             theme = theme_bw()),
         "ggplot")
 })
@@ -114,24 +109,24 @@ test_that("dittoBarPlots titles and theme can be adjusted", {
 test_that("dittoBarPlots y-axis can be adjusted", {
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             y.breaks = seq(0,1,0.25)),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             min = -0.5, max = 2,
             y.breaks = seq(0,1,0.25)),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             scale = "count",
             y.breaks = seq(0,45,15)),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             scale = "count",
             min = -5, max = 55,
             y.breaks = seq(0,45,15)),
@@ -142,13 +137,13 @@ test_that("dittoBarPlot var-labels can be adjusted and reordered", {
     # Manual Check: groups changed to pikachu and libre.
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             var.labels.rename = c("pikachu", "squirtle", "ivysaur", "charizard")),
         "ggplot")
     # Manual Check: 1 on top of zero, with colors reversed too (orange still on top).
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             var.labels.reorder = 4:1),
         "ggplot")
 })
@@ -156,30 +151,30 @@ test_that("dittoBarPlot var-labels can be adjusted and reordered", {
 test_that("dittoBarPlots x-labels can be adjusted", {
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             x.labels = 4:7),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             x.reorder = 4:1),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             x.labels.rotate = FALSE),
         "ggplot")
     ### Manual Check: L->R 4:7, with horizontal labels
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             scale = "count",
             x.labels = 4:7, x.reorder = 4:1, x.labels.rotate = FALSE),
         "ggplot")
     ### Manual Check: L->R 4:7, but order reversed compared to above
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             scale = "count",
             x.labels = 4:7, x.labels.rotate = FALSE),
         "ggplot")
@@ -188,27 +183,27 @@ test_that("dittoBarPlots x-labels can be adjusted", {
 test_that("dittoBarPlot can be faceted with 'split.by'", {
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             split.by = grp1),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             split.by = c(grp1,grp3)),
         "ggplot")
     
     # Work with cells.use
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             split.by = grp1,
-            cells.use = seurat$number<50),
+            cells.use = sce$number<50),
         "ggplot")
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             split.by = c(grp1,grp3),
-            cells.use = seurat$number<50),
+            cells.use = sce$number<50),
         "ggplot")
 })
 
@@ -216,8 +211,8 @@ test_that("'split.by' can be given extra features", {
     # MANUAL: white space utilized fully
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3, scale = "count", split.ncol = 1,
-            cells.use = meta(grp3,seurat)==1,
+            sce, grp2, group.by = grp3, scale = "count", split.ncol = 1,
+            cells.use = meta(grp3,sce)==1,
             split.by = grp1,
             split.adjust = list(scales = "free"), max = NA
             ),
@@ -225,26 +220,26 @@ test_that("'split.by' can be given extra features", {
     # MANUAL: white space utilized fully
     expect_s3_class(
         dittoBarPlot(
-            seurat, grp2, group.by = grp3,
+            sce, grp2, group.by = grp3,
             split.by = c(grp1,grp3),
             split.adjust = list(scales = "free")),
         "ggplot")
 })
 
 test_that("dittoBarPlot, 'retain.factor.level' can be used to respect factor levels", {
-    seurat$var_factor <- factor(
-        meta(grp2, seurat),
-        levels = rev(metaLevels(grp2, seurat)))
-    seurat$grp_factor <- factor(
-        meta(grp3, seurat),
-        levels = rev(metaLevels(grp3, seurat)))
+    sce$var_factor <- factor(
+        meta(grp2, sce),
+        levels = rev(metaLevels(grp2, sce)))
+    sce$grp_factor <- factor(
+        meta(grp3, sce),
+        levels = rev(metaLevels(grp3, sce)))
     
     # MANUAL: var and group.by ordering should be reverse of alpha-numeric
     #  & group.by-1 should remain.
     expect_s3_class(
         dittoBarPlot(
-            seurat, "var_factor", group.by = "grp_factor",
+            sce, "var_factor", group.by = "grp_factor",
             retain.factor.levels = TRUE,
-            cells.use = meta("grp_factor",seurat)!=1),
+            cells.use = meta("grp_factor",sce)!=1),
         "ggplot")
 })

--- a/tests/testthat/test-DemuxImport.R
+++ b/tests/testthat/test-DemuxImport.R
@@ -24,14 +24,9 @@ names(samples) <- NULL
 samples_NAatEnd <- samples
 samples_NAatEnd[71:ncol(sce)] <- NA
 
-test_that("importDemux works when all barcodes are there (Seurat and SCE)", {
+test_that("importDemux works when all barcodes are there", {
     expect_s4_class(
         t <- importDemux(
-            object = seurat.noDash, lane.meta = "groups",
-            demuxlet.best = "mock_demux.best"),
-        "Seurat")
-    expect_s4_class(
-        importDemux(
             object = sce.noDash, lane.meta = "groups",
             demuxlet.best = "mock_demux.best"),
         "SingleCellExperiment")
@@ -39,34 +34,24 @@ test_that("importDemux works when all barcodes are there (Seurat and SCE)", {
     expect_true(all(samples == meta("Sample", t)))
 })
 
-test_that("importDemux can name lanes with 'lane.names' (Seurat and SCE)", {
-    expect_s4_class(
-        t <- importDemux(
-            seurat.noDash, lane.meta = "groups",
-            lane.names = metaLevels("groups", seurat),
-            demuxlet.best = "mock_demux.best"
-            ),
-        "Seurat")
-    expect_equal(
-        metaLevels("Lane",t),
-        metaLevels("groups", seurat)
-    )
+test_that("importDemux can name lanes with 'lane.names'", {
     expect_s4_class(
         t <- importDemux(
             sce.noDash, lane.meta = "groups",
-            lane.names = metaLevels("groups", seurat),
+            lane.names = metaLevels("groups", sce),
             demuxlet.best = "mock_demux.best"
             ),
         "SingleCellExperiment")
+    # Lane identities are correct
+    expect_equal(
+        metaLevels("Lane",t),
+        metaLevels("groups", sce)
+    )
     # All called samples are correct
     expect_true(all(samples == meta("Sample", t)))
 })
 
-test_that("importDemux works when some barcodes are not there (Seurat and SCE)", {
-    expect_s4_class(
-        importDemux(
-            seurat.noDash, lane.meta = "groups", demuxlet.best = "mock_demux_missing10.best"),
-        "Seurat")
+test_that("importDemux works when some barcodes are not there", {
     expect_s4_class(
         t <- importDemux(
             sce.noDash, lane.meta = "groups", demuxlet.best = "mock_demux_missing10.best"),
@@ -77,13 +62,7 @@ test_that("importDemux works when some barcodes are not there (Seurat and SCE)",
     expect_true(all(is.na(samples_NAatEnd) == is.na(meta("Sample", t))))
 })
 
-test_that("importDemux works with incremented -# and multiple .best given (Seurat and SCE)", {
-    expect_s4_class(
-        importDemux(
-            seurat3,
-            demuxlet.best = c("mock_demux_1st45.best",
-                              "mock_demux_2nd35.best")),
-        "Seurat")
+test_that("importDemux works with incremented -# and multiple .best given", {
     expect_s4_class(
         t <- importDemux(
             sce3,
@@ -94,13 +73,7 @@ test_that("importDemux works with incremented -# and multiple .best given (Seura
     expect_true(all(samples == meta("Sample", t)))
 })
 
-test_that("importDemux works with incremented -# and multiple .best given when some cells not in a .best (Seurat and SCE)", {
-    expect_s4_class(
-        importDemux(
-            seurat2,
-            demuxlet.best = c("mock_demux_1st45.best",
-                              "mock_demux_2nd35.best")),
-        "Seurat")
+test_that("importDemux works with incremented -# and multiple .best given when some cells not in a .best", {
     expect_s4_class(
         t <- importDemux(
             sce2,
@@ -116,11 +89,6 @@ test_that("importDemux works with incremented -# and multiple .best given when s
 test_that("importDemux reads lanes from -# names", {
     expect_s4_class(
         t <- importDemux(
-            seurat2, demuxlet.best = "mock_demux_-num2Lanes.best"),
-        "Seurat")
-    expect_equal(length(metaLevels("Lane",t)), 2)
-    expect_s4_class(
-        t <- importDemux(
             sce2, demuxlet.best = "mock_demux_-num2Lanes.best"),
         "SingleCellExperiment")
     expect_equal(length(metaLevels("Lane",t)), 2)
@@ -133,11 +101,11 @@ test_that("importDemux reads lanes from -# names", {
 test_that("importDemux can be verbose or not", {
     expect_message(
         importDemux(
-            seurat.noDash, demuxlet.best = "mock_demux.best",
+            sce.noDash, demuxlet.best = "mock_demux.best",
             verbose = TRUE))
     expect_message(
         importDemux(
-            seurat.noDash, demuxlet.best = "mock_demux.best",
+            sce.noDash, demuxlet.best = "mock_demux.best",
             verbose = FALSE),
         NA)
 })
@@ -145,58 +113,59 @@ test_that("importDemux can be verbose or not", {
 test_that("importDemux gives error when no barcodes match", {
     expect_error(
         importDemux(
-            seurat, demuxlet.best = "mock_demux.best",
+            sce, demuxlet.best = "mock_demux.best",
             verbose = FALSE),
         "No barcodes match between 'object' and 'demuxlet.best'", fixed = TRUE)
 })
 
-seurat.demux <- importDemux(
-    seurat.noDash, lane.meta = "groups",
+# Now for the Visualizations
+sce.demux <- importDemux(
+    sce.noDash, lane.meta = "groups",
     demuxlet.best = "mock_demux.best",
     verbose = FALSE)
 
 test_that("demux.SNP.summary version of dittoPlot works", {
     expect_s3_class(
-        demux.SNP.summary(seurat.demux),
+        demux.SNP.summary(sce.demux),
         "ggplot")
 })
 
 test_that("demux.calls.summary works", {
     expect_s3_class(
-        demux.calls.summary(seurat.demux),
+        demux.calls.summary(sce.demux),
         "ggplot")
 })
 
 test_that("demux.calls.summary options work", {
     expect_s3_class(
-        demux.calls.summary(seurat.demux,
+        demux.calls.summary(sce.demux,
             singlets.only = TRUE),
         "ggplot")
     expect_s3_class(
-        demux.calls.summary(seurat.demux,
+        demux.calls.summary(sce.demux,
             rotate.labels = FALSE),
         "ggplot")
     expect_s3_class(
-        demux.calls.summary(seurat.demux,
+        demux.calls.summary(sce.demux,
             data.out = TRUE),
         "data.frame")
     expect_s3_class(
-        demux.calls.summary(seurat.demux,
+        demux.calls.summary(sce.demux,
             theme = theme_bw()),
         "ggplot")
     expect_s3_class(
-        demux.calls.summary(seurat.demux,
+        demux.calls.summary(sce.demux,
             color = "yellow"),
         "ggplot")
     expect_s3_class(
-        demux.calls.summary(seurat.demux,
+        demux.calls.summary(sce.demux,
             main = "1",
             sub = "2",
             xlab = "3",
             ylab = "4"),
         "ggplot")
     expect_s3_class(
-        demux.calls.summary(seurat.demux,
+        demux.calls.summary(sce.demux,
             main = NULL,
             sub = NULL,
             xlab = NULL,

--- a/tests/testthat/test-DemuxImport.R
+++ b/tests/testthat/test-DemuxImport.R
@@ -3,15 +3,12 @@
 
 sce.noDash <- sce
 colnames(sce.noDash) <- sapply(colnames(sce.noDash), function(X) strsplit(X, "-")[[1]][1])
-seurat.noDash <- suppressWarnings(Seurat::as.Seurat(sce.noDash))
 
 sce2 <- sce.noDash
 colnames(sce2) <- paste(colnames(sce2), rep(1:2, each = 40)[seq_len(ncells)], sep = "-")
-seurat2 <- suppressWarnings(Seurat::as.Seurat(sce2))
 
 sce3 <- sce.noDash
 colnames(sce3) <- paste(colnames(sce3), c(rep(1, 45),rep(2, 35))[seq_len(ncells)], sep = "-")
-seurat3 <- suppressWarnings(Seurat::as.Seurat(sce3))
 
 ### Extract the proper samples calls
 best <- read.table(file = "mock_demux.best", header=TRUE, sep="\t", stringsAsFactors = FALSE)

--- a/tests/testthat/test-DimPlot-SE.R
+++ b/tests/testthat/test-DimPlot-SE.R
@@ -5,7 +5,7 @@ gene <- "gene1"
 cont <- "score2"
 disc <- "groups"
 disc2 <- "age"
-cells.names <- colnames(seurat)[1:40]
+cells.names <- colnames(sce)[1:40]
 cells.logical <- c(rep(TRUE, 40), rep(FALSE,ncells-40))
 cols <- c("red", "blue", "yellow", "green", "black", "gray", "white")
 
@@ -57,7 +57,7 @@ test_that("dittoDimPlots can be subset to show only certain cells/samples with a
     expect_s3_class(
         dittoDimPlot(
             disc, object = se, reduction.use = embeds,
-            cells.use = meta(disc,seurat)!="A"),
+            cells.use = meta(disc,sce)!="A"),
         "ggplot")
 })
 
@@ -189,17 +189,12 @@ test_that("dittoDimPlot can add extra vars to dataframe", {
 })
 
 test_that("dittoDimPlot genes can be different data types", {
-    df <- dittoDimPlot(gene, object = seurat, data.out = TRUE,
-        slot = "counts")
-    expect_equal(
-        df$Target_data$color,
-        round(df$Target_data$color,0))
-    df <- dittoDimPlot(gene, object = sce, data.out = TRUE,
+    df <- dittoDimPlot(gene, object = se, reduction.use = embeds, data.out = TRUE,
         assay = "counts")
     expect_equal(
         df$Target_data$color,
         round(df$Target_data$color,0))
-    df <- dittoDimPlot(gene, object = sce, data.out = TRUE,
+    df <- dittoDimPlot(gene, object = se, reduction.use = embeds, data.out = TRUE,
         adjustment = "relative.to.max")
     expect_equal(
         0:1,

--- a/tests/testthat/test-DimPlot.R
+++ b/tests/testthat/test-DimPlot.R
@@ -1,40 +1,32 @@
 # Tests for dittoDimPlot function
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-DimPlot.R")
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
+sce$number <- as.numeric(seq_along(colnames(sce)))
 gene <- "gene1"
 cont <- "number"
 disc <- "groups"
 disc2 <- "age"
-cells.names <- colnames(seurat)[1:40]
+cells.names <- colnames(sce)[1:40]
 cells.logical <- c(rep(TRUE, 40), rep(FALSE,ncells-40))
 cols <- c("red", "blue", "yellow", "green", "black", "gray", "white")
 
 test_that("dittoDimPlot can plot continuous or discrete data & raw or normalized expression", {
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat),
+            disc, object=sce),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat),
+            cont, object=sce),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            gene, object=seurat),
+            gene, object=sce),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            gene, object=seurat,
-            slot = "counts"),
-        "ggplot")
-})
-
-test_that("dittoDimPlot (and reduction.use defaults) work for sce too", {
-    # SCE
-    expect_s3_class(
-        dittoDimPlot(
-            disc,  object=sce),
+            gene, object=sce,
+            assay = "counts"),
         "ggplot")
 })
 
@@ -42,19 +34,19 @@ test_that("dittoDimPlot basic tweaks work", {
     # Manuel Check: big dots
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             size = 10),
         "ggplot")
     # Manuel Check: triangles
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             shape.panel = 17),
         "ggplot")
     # Manuel Check: see through large dots
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             size = 5,
             opacity = 0.5),
         "ggplot")
@@ -64,19 +56,19 @@ test_that("dittoDimPlot main legend can be removed or adjusted", {
     ### Manual Check: Legend removed
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             legend.show = FALSE),
         "ggplot")
     ### Manual Check: Legend title = "WOW"
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             legend.title = "WOW"),
         "ggplot")
     ### Manual Check: Legend symbols LARGE
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             legend.size = 15),
         "ggplot")
 })
@@ -84,18 +76,18 @@ test_that("dittoDimPlot main legend can be removed or adjusted", {
 test_that("dittoDimPlots can be subset to show only certain cells/samples with any cells.use method", {
     expect_s3_class(
         {c1 <- dittoDimPlot(
-            disc, object=seurat, data.out = TRUE,
+            disc, object=sce, data.out = TRUE,
             cells.use = cells.names)
         c1$p},
         "ggplot")
     expect_s3_class(
         {c2 <- dittoDimPlot(
-            disc, object=seurat, data.out = TRUE,
+            disc, object=sce, data.out = TRUE,
             cells.use = cells.logical)
         c2$p},
         "ggplot")
     c3 <- dittoDimPlot(
-        disc, object=seurat,
+        disc, object=sce,
         cells.use = 1:40,
         data.out = TRUE)
     expect_equal(c1$Target_data, c2$Target_data)
@@ -104,25 +96,25 @@ test_that("dittoDimPlots can be subset to show only certain cells/samples with a
     # And if we remove an entire grouping...
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
-            cells.use = meta(disc,seurat)!="A"),
+            disc, object=sce,
+            cells.use = meta(disc,sce)!="A"),
         "ggplot")
 })
 
 test_that("dittoDimPlot shapes can be a metadata and the same as or distinct from var", {
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             shape.by = disc),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             shape.by = disc),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             shape.by = disc2),
         "ggplot")
 })
@@ -131,19 +123,19 @@ test_that("dittoDimPlot shapes can be adjusted in many ways", {
     ### Manual check: Shapes should be triangle and diamond
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             shape.by = disc2, shape.panel= 17:19),
         "ggplot")
     ### Manual check: Shapes should be enlarged even more in the legend
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             shape.by = disc2, shape.legend.size = 10),
         "ggplot")
     ### Manual check: Shapes legend title should be removed
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             shape.by = disc2, shape.legend.title = NULL),
         "ggplot")
 })
@@ -152,15 +144,15 @@ test_that("dittoDimPlot reduction.use can be changed", {
     ### Manuel Check: these should all look obviously distinct
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat),
+            cont, object=sce),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat, reduction.use = "PCA"),
+            cont, object=sce, reduction.use = "PCA"),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat, reduction.use = "PCA",
+            cont, object=sce, reduction.use = "PCA",
             dim.1 = 3, dim.2 = 5),
         "ggplot")
 })
@@ -168,18 +160,18 @@ test_that("dittoDimPlot reduction.use can be changed", {
 test_that("dittoDimPlots colors can be adjusted for discrete data", {
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             color.panel = cols),
         "ggplot")
     ### Manual check: These two should look the same.
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             color.panel = cols[6:1]),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             color.panel = cols,
             colors = 6:1),
         "ggplot")
@@ -188,17 +180,17 @@ test_that("dittoDimPlots colors can be adjusted for discrete data", {
 test_that("dittoDimPlots color scales can be adjusted for continuous data", {
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             min = -5, max = 100),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             legend.breaks = seq(10,60,10)),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             legend.breaks = seq(10,60,10),
             legend.breaks.labels = c("WOW",2:5,"HEY!")),
         "ggplot")
@@ -208,7 +200,7 @@ test_that("dittoDimPlots titles and theme can be adjusted", {
     ### Manual check: All titles should be adjusted.
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             main = "Gotta catch", sub = "em all",
             xlab = "Pokemon", ylab = "Pokedex #s",
             legend.title = "groups"),
@@ -216,7 +208,7 @@ test_that("dittoDimPlots titles and theme can be adjusted", {
     ### Manual check: top and right plot outline removed
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             theme = theme_classic()),
         "ggplot")
 })
@@ -225,13 +217,13 @@ test_that("dittoDimPlots discrete labels can be adjusted", {
     # Manual Check: 5:9
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             rename.var.groups = 5:9),
         "ggplot")
     # Manual Check: 3:6
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             shape.by = disc2, rename.shape.groups = 3:6),
         "ggplot")
 })
@@ -241,31 +233,31 @@ test_that("dittoDimPlot can be labeled or circled", {
     # plots), and 1&3 with background, 2&4 without, 5: smaller labels
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             do.label = TRUE),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             do.label = TRUE,
             labels.highlight = FALSE),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             do.label = TRUE,
             labels.repel = FALSE),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             do.label = TRUE,
             labels.highlight = FALSE,
             labels.repel = FALSE),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             do.label = TRUE,
             labels.size = 3),
         "ggplot")
@@ -274,7 +266,7 @@ test_that("dittoDimPlot can be labeled or circled", {
 test_that("dittoDimPlot trajectory adding works", {
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             add.trajectory.lineages = list(
                 c("B","A","C"),
                 c("C","A")),
@@ -284,7 +276,7 @@ test_that("dittoDimPlot trajectory adding works", {
     # Manual Check: Arrows should move & GROW.
     expect_s3_class(
         dittoDimPlot(
-            cont, object=seurat,
+            cont, object=sce,
             add.trajectory.lineages = list(
                 c("C","A")),
             trajectory.cluster.meta = disc,
@@ -293,7 +285,7 @@ test_that("dittoDimPlot trajectory adding works", {
     # Manual Check: Arrows should be detached from points
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             add.trajectory.curves = list(
                 data.frame(
                     c(-10,0,-20),
@@ -310,13 +302,13 @@ test_that("dittoDimPlot lettering works", {
     ### Manual Check: Letters should be added
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             do.letter = TRUE, size = 3),
         "ggplot")
     ### Manual Check: see through dots and letters
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             do.letter = TRUE, size = 3,
             opacity = 0.5),
         "ggplot")
@@ -326,12 +318,12 @@ test_that("dittoDimPlot can remove axes numbers", {
     ### Manual Check: Numbers should be removed from the axes
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat, show.axes.numbers = FALSE),
+            disc, object=sce, show.axes.numbers = FALSE),
         "ggplot")
 })
 
 test_that("dittoDimPlot plotting order can be ordered by the data", {
-    out <- dittoDimPlot(disc, object=seurat, data.out = TRUE, size = 10, order = "decreasing")
+    out <- dittoDimPlot(disc, object=sce, data.out = TRUE, size = 10, order = "decreasing")
     ### Manual Check: Orange always in front
     expect_s3_class(
         out$p,
@@ -341,18 +333,18 @@ test_that("dittoDimPlot plotting order can be ordered by the data", {
         out$Target_data$color,
         rev(
             dittoDimPlot(
-                disc, object=seurat, data.out = TRUE, size = 10, order = "increasing"
+                disc, object=sce, data.out = TRUE, size = 10, order = "increasing"
                 )$Target_data$color)
     )
 })
 
 test_that("dittoDimPlot can add extra vars to dataframe", {
     df1 <- dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             data.out = TRUE)[[2]]
     expect_s3_class(
         df2 <- dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             extra.vars = c(gene, disc2), data.out = TRUE)[[2]],
         "data.frame")
     expect_equal(ncol(df1), 3)
@@ -360,11 +352,6 @@ test_that("dittoDimPlot can add extra vars to dataframe", {
 })
 
 test_that("dittoDimPlot genes can be different data types", {
-    df <- dittoDimPlot(gene, object = seurat, data.out = TRUE,
-        slot = "counts")
-    expect_equal(
-        df$Target_data$color,
-        round(df$Target_data$color,0))
     df <- dittoDimPlot(gene, object = sce, data.out = TRUE,
         assay = "counts")
     expect_equal(
@@ -378,12 +365,12 @@ test_that("dittoDimPlot genes can be different data types", {
 })
 
 test_that("dittoDimPlot adding contours", {
-    expect_s3_class(dittoDimPlot(object=seurat, disc,
+    expect_s3_class(dittoDimPlot(object=sce, disc,
         do.contour = TRUE),
         "ggplot")
     
     ### Manual Check: Contour lines light blue and dashed
-    expect_s3_class(dittoDimPlot(object=seurat, disc,
+    expect_s3_class(dittoDimPlot(object=sce, disc,
         do.contour = TRUE,
         contour.color = "lightblue", contour.linetype = "dashed"),
         "ggplot")
@@ -391,27 +378,27 @@ test_that("dittoDimPlot adding contours", {
 
 test_that("dittoDimPlot with and without rasterization produces identical plots", {
     ### Manual Check: Plots should appear identical
-    expect_s3_class(dittoDimPlot(object=seurat, disc,
+    expect_s3_class(dittoDimPlot(object=sce, disc,
         do.raster = TRUE),
         "ggplot")
-    
-    expect_s3_class(dittoDimPlot(object=seurat, disc),
+
+    expect_s3_class(dittoDimPlot(object=sce, disc),
         "ggplot")
 })
 
 test_that("dittoDimPlot ignores do.letter/do.label/do.ellipse for continuous data", {
-    expect_message(dittoDimPlot(object=seurat, cont,
+    expect_message(dittoDimPlot(object=sce, cont,
         do.label = TRUE),
         "do.label was/were ignored for non-discrete data", fixed = TRUE)
-    expect_message(dittoDimPlot(object=seurat, cont,
+    expect_message(dittoDimPlot(object=sce, cont,
         do.letter = TRUE),
         "do.letter was/were ignored for non-discrete data", fixed = TRUE)
-    expect_message(dittoDimPlot(object=seurat, cont,
+    expect_message(dittoDimPlot(object=sce, cont,
         do.ellipse = TRUE),
         "do.ellipse was/were ignored for non-discrete data", fixed = TRUE)
     
-    # No message for discrete data && MANUAAL CHECK: ellipse is drawn 
-    expect_message(dittoDimPlot(object=seurat, disc,
+    # No message for discrete data && MANUAL CHECK: ellipse is drawn 
+    expect_message(dittoDimPlot(object=sce, disc,
         do.ellipse = TRUE),
         NA)
 })
@@ -420,27 +407,27 @@ test_that("dittoDimPlot can be faceted with split.by (1 or 2 vars)", {
     # MANUAL CHECK: FACETING
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2),
         "ggplot")
     # horizontal
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             split.nrow = 1),
         "ggplot")
     # vertical
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             split.ncol = 1),
         "ggplot")
     # Grid with rows=age, cols=groups
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc)),
         "ggplot")
 })
@@ -449,14 +436,14 @@ test_that("dittoDimPlot faceting and cell.use and split.show.all.others work tog
     # MANUAL: Works with cells.use (should have grey cells)
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2),
             cells.use = cells.logical,
             split.show.all.others = FALSE),
         "ggplot")
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc),
             cells.use = cells.logical,
             split.show.all.others = FALSE),
@@ -465,7 +452,7 @@ test_that("dittoDimPlot faceting and cell.use and split.show.all.others work tog
     # MANUAL: Works with split.show.all.others on (should even more grey cells)
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc),
             cells.use = cells.logical,
             split.show.all.others = TRUE),
@@ -473,7 +460,7 @@ test_that("dittoDimPlot faceting and cell.use and split.show.all.others work tog
     # MANUAL: Works with split.show.all.others on (should even more grey cells)
     expect_s3_class(
         dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc),
             cells.use = cells.logical,
             split.show.all.others = TRUE),
@@ -483,35 +470,35 @@ test_that("dittoDimPlot faceting and cell.use and split.show.all.others work tog
 test_that("dittoDimPlot added features work with single-metadata faceting", {
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             do.label = TRUE,
             split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             do.ellipse = TRUE,
             split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             do.letter = TRUE,
             split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             do.contour = TRUE,
             split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             add.trajectory.lineages = list(
                     c("C","A")),
@@ -520,7 +507,7 @@ test_that("dittoDimPlot added features work with single-metadata faceting", {
         NA)
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             add.trajectory.curves = list(
                 data.frame(
@@ -536,28 +523,28 @@ test_that("dittoDimPlot added features work with single-metadata faceting", {
 test_that("dittoDimPlot added features work with double-metadata faceting", {
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc),
             do.label = TRUE,
             split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc),
             do.ellipse = TRUE,
             split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc),
             do.letter = TRUE,
             split.show.all.others = FALSE)),
         NA)
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc),
             add.trajectory.lineages = list(
                     c("C","A")),
@@ -566,7 +553,7 @@ test_that("dittoDimPlot added features work with double-metadata faceting", {
         NA)
     expect_error(
         print(dittoDimPlot(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc),
             add.trajectory.curves = list(
                 data.frame(
@@ -584,4 +571,3 @@ test_that("dittoDimPlot swap.rownames works", {
         dittoDimPlot(sce, "gene1_symb", swap.rownames = "symbol"),
         "ggplot")
 })
-

--- a/tests/testthat/test-DotPlot.R
+++ b/tests/testthat/test-DotPlot.R
@@ -1,38 +1,24 @@
 # Tests for dittoDotPlot function
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-DotPlot.R")
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
-seurat$number2 <- rev(seurat$number)
+sce$number <- as.numeric(seq_along(colnames(sce)))
+sce$number2 <- rev(sce$number)
 disc <- "clusters"
 disc2 <- "groups"
 disc3 <- "age"
-genes <- getGenes(seurat)[1:5]
+genes <- getGenes(sce)[1:5]
 metas <- c("score", "score2", "score3")
-cells.names <- colnames(seurat)[1:40]
+cells.names <- colnames(sce)[1:40]
 cells.logical <- c(rep(TRUE, 40), rep(FALSE,ncells-40))
 
-test_that("dittoDotPlot can plot gene and meta data with Seurat or SCE", {
-    expect_s3_class(
-        print(dittoDotPlot(seurat, group.by = disc,
-            genes)),
-        "ggplot")
+test_that("dittoDotPlot can plot gene and meta data", {
     expect_s3_class(
         dittoDotPlot(sce, group.by = disc,
             genes),
         "ggplot")
-    
-    expect_s3_class(
-        dittoDotPlot(seurat, group.by = disc,
-            metas),
-        "ggplot")
     expect_s3_class(
         dittoDotPlot(sce, group.by = disc,
             metas),
-        "ggplot")
-    
-    expect_s3_class(
-        dittoDotPlot(seurat, group.by = disc,
-            c("score", "gene1")),
         "ggplot")
     expect_s3_class(
         dittoDotPlot(sce, group.by = disc,
@@ -42,56 +28,44 @@ test_that("dittoDotPlot can plot gene and meta data with Seurat or SCE", {
 
 test_that("dittoDotPlot errors for single vars or non-numeric vars", {
     expect_error(
-        dittoDotPlot(seurat, group.by = disc,
+        dittoDotPlot(sce, group.by = disc,
             c("score")),
         "'vars' must be a vector of at least two", fixed = TRUE)
     
     expect_error(
-        dittoDotPlot(seurat, group.by = disc,
+        dittoDotPlot(sce, group.by = disc,
             c("gene1")),
         "'vars' must be a vector of at least two", fixed = TRUE)
     expect_error(
-        dittoDotPlot(seurat, group.by = disc,
+        dittoDotPlot(sce, group.by = disc,
             c("gene1", "gene2", disc)),
         "'vars' must be numeric", fixed = TRUE)
 })
 
 test_that("dittoDotPlot works with any gene adjustments", {
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             adjustment = "relative.to.max"),
         "ggplot")
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             adjustment = "z-score"),
         "ggplot")
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             adjustment = NULL),
         "ggplot")
-})
-
-test_that("dittoDotPlot data.out works", {
-    # scaling on by default
-    expect_type(
-        d <- dittoDotPlot(seurat, genes, disc,
-            data.out = TRUE),
-        "list")
-    
-    expect_equal(names(d), c("p", "data"))
-    expect_s3_class(d$p, "ggplot")
-    expect_s3_class(d$data, "data.frame")
 })
 
 test_that("dittoDotPlot scaling acts as expected", {
     # scaling on by default
     expect_type(
-        d <- dittoDotPlot(seurat, genes, disc,
+        d <- dittoDotPlot(sce, genes, disc,
             data.out = TRUE),
         "list")
     # Controlled by 'scale'
     expect_type(
-        d2 <- dittoDotPlot(seurat, genes, disc,
+        d2 <- dittoDotPlot(sce, genes, disc,
             scale = FALSE,
             data.out = TRUE),
         "list")
@@ -102,7 +76,7 @@ test_that("dittoDotPlot scaling acts as expected", {
 
 test_that("dittoDotPlot legend can be removed", {
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             legend.show = FALSE),
         "ggplot")
 })
@@ -110,16 +84,16 @@ test_that("dittoDotPlot legend can be removed", {
 test_that("dittoDotPlot summary.fxns can be adjusted", {
     # Manual check: scale of color in 1, should have same range as size in 2.
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             summary.fxn.color = median),
         "ggplot")
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             summary.fxn.size = median),
         "ggplot")
     
     expect_error(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             summary.fxn.color = function(x) x/2),
         "result is length", fixed = TRUE)
 })
@@ -127,21 +101,21 @@ test_that("dittoDotPlot summary.fxns can be adjusted", {
 test_that("dittoDotPlot colors, sizes, ranges, legends are adjustable", {
     # Manual check: color = black to light grey, -3 to 3.
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             min.color = "black", max.color = "grey90",
             min = -3, max = 3),
         "ggplot")
     
     # Manual check: size = -0.25 to 1, dots LARGE
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             min.percent = -0.25, max.percent = 1,
             size = 10),
         "ggplot")
     
     # Manual check: color = 3 breaks, low, 0, high
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             min = -3, max = 3,
             legend.color.breaks = seq(-3,3,3),
             legend.color.breaks.labels = c("low", 0, "high")),
@@ -150,31 +124,31 @@ test_that("dittoDotPlot colors, sizes, ranges, legends are adjustable", {
 
 test_that("dittoDotPlot can be subset to show only certain cells/samples with any cells.use method", {
     expect_s3_class(
-        {c1 <- dittoDotPlot(seurat, genes, disc, data.out = TRUE,
+        {c1 <- dittoDotPlot(sce, genes, disc, data.out = TRUE,
             cells.use = cells.names)
         c1$p},
         "ggplot")
     expect_s3_class(
-        {c2 <- dittoDotPlot(seurat, genes, disc, data.out = TRUE,
+        {c2 <- dittoDotPlot(sce, genes, disc, data.out = TRUE,
             cells.use = cells.logical)
         c2$p},
         "ggplot")
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             cells.use = 1:40),
         "ggplot")
     expect_equal(c1$data,c2$data)
     # And if we remove an entire grouping...
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
-            cells.use = meta(disc,seurat)!=0),
+        dittoDotPlot(sce, genes, disc,
+            cells.use = meta(disc,sce)!=0),
         "ggplot")
 })
 
 test_that("dittoDotPlot titles and theme can be adjusted", {
     ### Manual check: All titles should be adjusted.
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             main = "Gotta catch", sub = "em all",
             xlab = "Pokemon", ylab = "Pokedex #s",
             legend.size.title = "Pika",
@@ -182,7 +156,7 @@ test_that("dittoDotPlot titles and theme can be adjusted", {
         "ggplot")
     ### Manual check: plot should be boxed with grid lines
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             theme = theme_bw()),
         "ggplot")
 })
@@ -190,40 +164,29 @@ test_that("dittoDotPlot titles and theme can be adjusted", {
 test_that("dittoDotPlot y-labels can be adjusted", {
     # Manual check: Labels = 3,4,5,6
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             y.labels = 3:6),
         "ggplot")
     # Manual check: 4 at bottom
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             y.reorder = 4:1),
         "ggplot")
     # Manual check: x-labels horizontal
     expect_s3_class(
-        dittoDotPlot(seurat, genes, disc,
+        dittoDotPlot(sce, genes, disc,
             x.labels.rotate = FALSE),
         "ggplot")
 })
 
-test_that("dittoDotPlot assay, slot, adjustment work", {
-    expect_type(
-        d_raw <- dittoDotPlot(seurat, genes, disc, data.out = TRUE, scale = FALSE,
-            slot = "counts"),
-        "list")
-    expect_type(
-        d_log <- dittoDotPlot(seurat, genes, disc, data.out = TRUE, scale = FALSE,
-            slot = "data"),
-        "list")
-    expect_true(all(
-        d_raw$data$color >= d_log$data$color))
-    
+test_that("dittoDotPlot assay adjustment works", {
     expect_type(
         d_raw <- dittoDotPlot(sce, genes, disc, data.out = TRUE, scale = FALSE,
             assay = "counts"),
         "list")
     expect_type(
         d_log <- dittoDotPlot(sce, genes, disc, data.out = TRUE, scale = FALSE,
-            slot = "logcounts"),
+            assay = "logcounts"),
         "list")
     expect_true(all(
         d_raw$data$color >= d_log$data$color))

--- a/tests/testthat/test-Heatmap-complex.R
+++ b/tests/testthat/test-Heatmap-complex.R
@@ -1,17 +1,12 @@
 # Tests for dittoHeatmap - ComplexHeatmap output
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-Heatmap-complex.R")
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
-seurat$number2 <- as.numeric(rev(seq_along(colnames(seurat))))
-genes <- getGenes(seurat)[1:9]
+sce$number <- as.numeric(seq_along(colnames(sce)))
+sce$number2 <- as.numeric(rev(seq_along(colnames(sce))))
+genes <- getGenes(sce)[1:9]
 metas <- c("score", "score2", "score3")
 
-test_that("Heatmap can be plotted for Seurat or SCE", {
-    expect_s4_class(
-        dittoHeatmap(complex = TRUE,
-            genes = genes,
-            object = seurat),
-        "HeatmapList")
+test_that("Heatmap can be plotted for SCE, both genes and metas", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
@@ -28,8 +23,8 @@ test_that("Heatmap data type can be adjusted", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
-            slot = "counts"), # normally raw.data, but as.Seurat......
+            object = sce,
+            assay = "counts"),
         "HeatmapList")
 })
 
@@ -45,14 +40,14 @@ test_that("Heatmap gives warnings/errors when genes missing", {
         dittoHeatmap(complex = TRUE,
             genes = genes,
             object = sce2,
-            cells.use = meta("number", seurat)<5),
+            cells.use = meta("number", sce)<5),
         "Gene(s) or metadata removed due to absence of non-zero values within the 'cells.use' subset", fixed = TRUE)
     # Function throws an error when no genes provided are captured in the target cells.
     expect_error(
         dittoHeatmap(complex = TRUE,
             genes = genes[1:5],
             object = sce2,
-            cells.use = meta("number", seurat)<10),
+            cells.use = meta("number", sce)<10),
         "No target genes/metadata features have non-zero values in the 'cells.use' subset", fixed = TRUE)
 
     # And now for metadata.
@@ -61,7 +56,7 @@ test_that("Heatmap gives warnings/errors when genes missing", {
             genes = NULL,
             metas = metas,
             object = sce2,
-            cells.use = meta("number", seurat)<5),
+            cells.use = meta("number", sce)<5),
         "Gene(s) or metadata removed due to absence of non-zero values within the 'cells.use' subset", fixed = TRUE)
     # Function throws an error when no metas provided are captured in the target cells.
     expect_error(
@@ -69,7 +64,7 @@ test_that("Heatmap gives warnings/errors when genes missing", {
             genes = NULL,
             metas = metas[1],
             object = sce2,
-            cells.use = meta("number", seurat)<10),
+            cells.use = meta("number", sce)<10),
         "No target genes/metadata features have non-zero values in the 'cells.use' subset", fixed = TRUE)
 })
 
@@ -103,7 +98,7 @@ test_that("Heatmap title can be adjusted", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             main = "Hello there!"),
         "HeatmapList")
 })
@@ -113,7 +108,7 @@ test_that("Heatmap sample renaming by metadata works", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             cell.names.meta = "number"),
         "HeatmapList")
 })
@@ -123,14 +118,14 @@ test_that("Heatmap can hide rownames/colnames", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             show_colnames = TRUE),
         "HeatmapList")
     ### No rownames
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             show_rownames = FALSE),
         "HeatmapList")
 })
@@ -140,7 +135,7 @@ test_that("Heatmap highlight genes works", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             show_colnames = FALSE,
             show_rownames = FALSE,
             highlight.features = "gene1"),
@@ -152,7 +147,7 @@ test_that("Heatmap can be scaled to max", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             scaled.to.max = TRUE),
         "HeatmapList")
 })
@@ -162,14 +157,14 @@ test_that("Heatmap colors can be adjusted", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             heatmap.colors = colorRampPalette(c("yellow", "black", "red"))(50)),
         "HeatmapList")
     ### black to yellow, 0:1
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             scaled.to.max = TRUE,
             heatmap.colors.max.scaled = colorRampPalette(c("black", "yellow"))(25)),
         "HeatmapList")
@@ -181,7 +176,7 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             order.by = "gene1"),
         "HeatmapList")
     # Works for metadata
@@ -189,7 +184,7 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             order.by = "groups",
             annot.by = "groups"),
         "HeatmapList")
@@ -198,9 +193,9 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "number2",
-            order.by = seq_along(colnames(seurat))),
+            order.by = seq_along(colnames(sce))),
         "HeatmapList")
 })
 
@@ -210,7 +205,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "clusters"),
         "HeatmapList")
     # Samples should not be ordered by this (bulk)
@@ -226,7 +221,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "clusters",
             cluster_cols = TRUE),
         "HeatmapList")
@@ -235,7 +230,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("clusters", "groups"),
             order.by = "groups"),
         "HeatmapList")
@@ -247,28 +242,28 @@ test_that("Heatmap can be ordered when also subset to certain cells", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             order.by = "gene1",
-            cells.use = meta("number", seurat)<20),
+            cells.use = meta("number", sce)<20),
         "HeatmapList")
     # Works for metadata
     ### ordered by groups metadata
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "groups",
-            cells.use = colnames(seurat)[meta("number", seurat)<20]),
+            cells.use = colnames(sce)[meta("number", sce)<20]),
         "HeatmapList")
     # Works with vectors provided
     ### ordered in REVERSE of the number annotations
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "number2",
-            order.by = seq_along(colnames(seurat)),
-            cells.use = colnames(seurat)[meta("number", seurat)<20]),
+            order.by = seq_along(colnames(sce)),
+            cells.use = colnames(sce)[meta("number", sce)<20]),
         "HeatmapList")
 })
 
@@ -278,23 +273,23 @@ test_that("Heatmap can be subset to certain cells by any method", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
-            cells.use = meta("number", seurat)<10), # Logical method
+            object = sce,
+            cells.use = meta("number", sce)<10), # Logical method
         "HeatmapList")
     # By names
     ### Same few cells
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
-            cells.use = colnames(seurat)[meta("number", seurat)<10]), # names method
+            object = sce,
+            cells.use = colnames(sce)[meta("number", sce)<10]), # names method
         "HeatmapList")
     # By indices
     ### Same few cells
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             cells.use = 1:9), # names method
         "HeatmapList")
 })
@@ -306,7 +301,7 @@ test_that("Heatmap annotation colors can be adjusted via annot.colors", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("number","clusters"),
             annot.colors = c("red", "yellow", "blue", "purple", "green3")),
         "HeatmapList")
@@ -323,7 +318,7 @@ test_that("Heatmap annotation colors can be adjusted via annotation_colors", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("number","clusters"),
             annotation_colors = color_list),
         "HeatmapList")
@@ -335,7 +330,7 @@ test_that("Heatmap annotation colors can be adjusted via annotation_colors", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("clusters"),
             annotation_colors = color_list),
         "HeatmapList")
@@ -346,7 +341,7 @@ test_that("Coloring works for discrete column and row annotations", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("clusters", "groups"),
             scaled.to.max = TRUE,
             annotation_row = data.frame(
@@ -360,7 +355,7 @@ test_that("Coloring works for continuous column and row annotations", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "number",
             scaled.to.max = TRUE,
             annotation_row = data.frame(
@@ -374,7 +369,7 @@ test_that("Coloring works for continuous column and row annotations", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "number2",
             order.by = "number",
             scaled.to.max = TRUE,
@@ -388,11 +383,11 @@ test_that("Coloring works for continuous column and row annotations", {
 
 test_that("scale and border_color pheatmap inputs function as expected", {
     expect_s4_class(
-        dittoHeatmap(complex = TRUE,genes = genes, object = seurat,
+        dittoHeatmap(complex = TRUE,genes = genes, object = sce,
             scale = "none"),
         "HeatmapList")
     expect_s4_class(
-        dittoHeatmap(complex = TRUE,genes = genes, object = seurat,
+        dittoHeatmap(complex = TRUE,genes = genes, object = sce,
             border_color = "red"),
         "HeatmapList")
 })
@@ -400,7 +395,7 @@ test_that("scale and border_color pheatmap inputs function as expected", {
 test_that("Rasterization works for ComplexHeatmap", {
     # Manual Check: zooming in drastically should reveal unequal row/column widths.
     expect_s4_class(
-        dittoHeatmap(complex = TRUE, genes = genes, object = seurat,
+        dittoHeatmap(complex = TRUE, genes = genes, object = sce,
             use_raster = TRUE, raster_quality = 1),
         "HeatmapList")
 })

--- a/tests/testthat/test-Heatmap.R
+++ b/tests/testthat/test-Heatmap.R
@@ -1,17 +1,12 @@
 # Tests for visualization functions
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-Heatmap.R")
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
-seurat$number2 <- as.numeric(rev(seq_along(colnames(seurat))))
-genes <- getGenes(seurat)[1:9]
+sce$number <- as.numeric(seq_along(colnames(sce)))
+sce$number2 <- as.numeric(rev(seq_along(colnames(sce))))
+genes <- getGenes(sce)[1:9]
 metas <- c("score", "score2", "score3")
 
-test_that("Heatmap can be plotted for Seurat or SCE", {
-    expect_s3_class(
-        dittoHeatmap(
-            genes = genes,
-            object = seurat),
-        "pheatmap")
+test_that("Heatmap can be plotted for SCE, both genes and metas", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
@@ -28,8 +23,8 @@ test_that("Heatmap data type can be adjusted", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
-            slot = "counts"), # normally raw.data, but as.Seurat......
+            object = sce,
+            assay = "counts"),
         "pheatmap")
 })
 
@@ -45,14 +40,14 @@ test_that("Heatmap gives warnings/errors when genes missing", {
         dittoHeatmap(
             genes = genes,
             object = sce2,
-            cells.use = meta("number", seurat)<5),
+            cells.use = meta("number", sce)<5),
         "Gene(s) or metadata removed due to absence of non-zero values within the 'cells.use' subset", fixed = TRUE)
     # Function throws an error when no genes provided are captured in the target cells.
     expect_error(
         dittoHeatmap(
             genes = genes[1:5],
             object = sce2,
-            cells.use = meta("number", seurat)<10),
+            cells.use = meta("number", sce)<10),
         "No target genes/metadata features have non-zero values in the 'cells.use' subset", fixed = TRUE)
 
     # And now for metadata.
@@ -61,7 +56,7 @@ test_that("Heatmap gives warnings/errors when genes missing", {
             genes = NULL,
             metas = metas,
             object = sce2,
-            cells.use = meta("number", seurat)<5),
+            cells.use = meta("number", sce)<5),
         "Gene(s) or metadata removed due to absence of non-zero values within the 'cells.use' subset", fixed = TRUE)
     # Function throws an error when no metas provided are captured in the target cells.
     expect_error(
@@ -69,7 +64,7 @@ test_that("Heatmap gives warnings/errors when genes missing", {
             genes = NULL,
             metas = metas[1],
             object = sce2,
-            cells.use = meta("number", seurat)<10),
+            cells.use = meta("number", sce)<10),
         "No target genes/metadata features have non-zero values in the 'cells.use' subset", fixed = TRUE)
 })
 
@@ -103,7 +98,7 @@ test_that("Heatmap title can be adjusted", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             main = "Hello there!"),
         "pheatmap")
 })
@@ -113,7 +108,7 @@ test_that("Heatmap sample renaming by metadata works", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             cell.names.meta = "number"),
         "pheatmap")
 })
@@ -123,14 +118,14 @@ test_that("Heatmap can hide rownames/colnames", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             show_colnames = TRUE),
         "pheatmap")
     ### No rownames
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             show_rownames = FALSE),
         "pheatmap")
 })
@@ -140,7 +135,7 @@ test_that("Heatmap highlight genes works", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             show_colnames = FALSE,
             show_rownames = FALSE,
             highlight.features = "gene1"),
@@ -152,7 +147,7 @@ test_that("Heatmap can be scaled to max", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             scaled.to.max = TRUE),
         "pheatmap")
 })
@@ -162,14 +157,14 @@ test_that("Heatmap colors can be adjusted", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             heatmap.colors = colorRampPalette(c("yellow", "black", "red"))(50)),
         "pheatmap")
     ### black to yellow, 0:1
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             scaled.to.max = TRUE,
             heatmap.colors.max.scaled = colorRampPalette(c("black", "yellow"))(25)),
         "pheatmap")
@@ -181,7 +176,7 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             order.by = "gene1"),
         "pheatmap")
     # Works for metadata
@@ -189,7 +184,7 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             order.by = "groups",
             annot.by = "groups"),
         "pheatmap")
@@ -198,17 +193,17 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "number2",
-            order.by = seq_along(colnames(seurat))),
+            order.by = seq_along(colnames(sce))),
         "pheatmap")
     ### Ordered in REVERSE of number2, with out of order cells FIRST
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "number2",
-            order.by = c(30:26, 1:25,31:ncol(seurat))),
+            order.by = c(30:26, 1:25,31:ncol(sce))),
         "pheatmap")
     
     # ordered by multiple metadata
@@ -216,7 +211,7 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             order.by = c("groups","number2"),
             annot.by = c("groups","number2")),
         "pheatmap")
@@ -228,7 +223,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "clusters"),
         "pheatmap")
     # Samples should not be ordered by this (bulk)
@@ -244,7 +239,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "clusters",
             cluster_cols = TRUE),
         "pheatmap")
@@ -253,7 +248,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("clusters", "groups"),
             order.by = "groups"),
         "pheatmap")
@@ -265,28 +260,28 @@ test_that("Heatmap can be ordered when also subset to certain cells", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             order.by = "gene1",
-            cells.use = meta("number", seurat)<20),
+            cells.use = meta("number", sce)<20),
         "pheatmap")
     # Works for metadata
     ### ordered by groups metadata
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "groups",
-            cells.use = colnames(seurat)[meta("number", seurat)<20]),
+            cells.use = colnames(sce)[meta("number", sce)<20]),
         "pheatmap")
     # Works with vectors provided
     ### ordered in REVERSE of the number annotations
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "number2",
-            order.by = seq_along(colnames(seurat)),
-            cells.use = colnames(seurat)[meta("number", seurat)<20]),
+            order.by = seq_along(colnames(sce)),
+            cells.use = colnames(sce)[meta("number", sce)<20]),
         "pheatmap")
 })
 
@@ -296,23 +291,23 @@ test_that("Heatmap can be subset to certain cells by any method", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
-            cells.use = meta("number", seurat)<10), # Logical method
+            object = sce,
+            cells.use = meta("number", sce)<10), # Logical method
         "pheatmap")
     # By names
     ### Same few cells
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
-            cells.use = colnames(seurat)[meta("number", seurat)<10]), # names method
+            object = sce,
+            cells.use = colnames(sce)[meta("number", sce)<10]), # names method
         "pheatmap")
     # By indices
     ### Same few cells
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             cells.use = 1:9), # names method
         "pheatmap")
 })
@@ -324,7 +319,7 @@ test_that("Heatmap annotation colors can be adjusted via annot.colors", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("number","clusters"),
             annot.colors = c("red", "yellow", "blue", "purple", "green3")),
         "pheatmap")
@@ -341,7 +336,7 @@ test_that("Heatmap annotation colors can be adjusted via annotation_colors", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("number","clusters"),
             annotation_colors = color_list),
         "pheatmap")
@@ -353,7 +348,7 @@ test_that("Heatmap annotation colors can be adjusted via annotation_colors", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("clusters"),
             annotation_colors = color_list),
         "pheatmap")
@@ -364,7 +359,7 @@ test_that("Coloring works for discrete column and row annotations", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = c("clusters", "groups"),
             scaled.to.max = TRUE,
             annotation_row = data.frame(
@@ -378,7 +373,7 @@ test_that("Coloring works for continuous column and row annotations", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "number",
             scaled.to.max = TRUE,
             annotation_row = data.frame(
@@ -392,7 +387,7 @@ test_that("Coloring works for continuous column and row annotations", {
     expect_s3_class(
         dittoHeatmap(
             genes = genes,
-            object = seurat,
+            object = sce,
             annot.by = "number2",
             order.by = "number",
             scaled.to.max = TRUE,
@@ -406,11 +401,11 @@ test_that("Coloring works for continuous column and row annotations", {
 
 test_that("scale and border_color pheatmap inputs function as expected", {
     expect_s3_class(
-        dittoHeatmap(genes = genes, object = seurat,
+        dittoHeatmap(genes = genes, object = sce,
             scale = "none"),
         "pheatmap")
     expect_s3_class(
-        dittoHeatmap(genes = genes, object = seurat,
+        dittoHeatmap(genes = genes, object = sce,
             border_color = "red"),
         "pheatmap")
 })

--- a/tests/testthat/test-Hex.R
+++ b/tests/testthat/test-Hex.R
@@ -8,20 +8,18 @@
 # - output the plot and dataframe as list with 'data.out = TRUE'
 ###########
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
+sce$number <- as.numeric(seq_along(colnames(sce)))
 gene <- "gene1"
 cont <- "number"
 disc <- "groups"
 disc2 <- "age"
-cells.names <- colnames(seurat)[1:40]
+cells.names <- colnames(sce)[1:40]
 cells.logical <- c(rep(TRUE, 40), rep(FALSE,ncells-40))
 cols <- c("red", "blue", "yellow", "green", "black", "gray", "white")
 
-test_that("DimHex & ScatterHex can plot density for Seurat or SCE", {
-    expect_s3_class(dittoDimHex(object=seurat), "ggplot")
+test_that("DimHex & ScatterHex can plot density for SCE", {
     expect_s3_class(dittoDimHex(object=sce), "ggplot")
-    expect_s3_class(dittoDimHex(gene, cont, object=seurat), "ggplot")
-    expect_s3_class(dittoDimHex(gene, cont, object=sce), "ggplot")
+    expect_s3_class(dittoDimHex(cont, object=sce), "ggplot")
 })
 
 test_that("dittoDimHex - bins input adjusts number of bins", {
@@ -29,61 +27,56 @@ test_that("dittoDimHex - bins input adjusts number of bins", {
     expect_s3_class(dittoDimHex(sce, bins = 5), "ggplot")
 })
 
-test_that("DimHex can plot continuous or discrete color.var data", {
+test_that("DimHex can plot continuous or discrete color.var data + 'adjustment'", {
     # Metadata
-    expect_s3_class(dittoDimHex(object=seurat, disc), "ggplot")
-    expect_s3_class(dittoDimHex(object=seurat, cont), "ggplot")
+    expect_s3_class(dittoDimHex(object=sce, disc), "ggplot")
+    expect_s3_class(dittoDimHex(object=sce, cont), "ggplot")
     # Expression
-    expect_s3_class((p1 <- dittoDimHex(object=seurat, gene, data.out = TRUE))[[1]], "ggplot")
-    expect_s3_class((p2 <- dittoDimHex(gene, object=seurat, slot = "counts", data.out = TRUE))$plot, "ggplot")
-    expect_s3_class((p3 <- dittoDimHex(gene, object=sce, assay = "counts", data.out = TRUE))$plot, "ggplot")
-    expect_s3_class((p4 <- dittoDimHex(gene, object=sce, adjustment = "relative.to.max", data.out = TRUE))$plot, "ggplot")
-    expect_false(identical(p1$data$color, p2$data$color))
-    expect_true(identical(p2$data$color, p3$data$color))
-    expect_equal(max(p4$data$color), 1)
+    expect_s3_class((p <- dittoDimHex(gene, object=sce, adjustment = "relative.to.max", data.out = TRUE))$plot, "ggplot")
+    expect_equal(max(p$data$color), 1)
 })
 
 test_that("DimHex - color.method options work for discrete data, and defaults to 'max'", {
     ### Manual: Should have continuous color-scale and max.props in its title
-    expect_s3_class(dittoDimHex(object=seurat, disc,
+    expect_s3_class(dittoDimHex(object=sce, disc,
         color.method = "max.prop"),
         "ggplot")
     
     ### Manual: Next 2 should be the same plot with discrete color legend and "max" in its title
-    expect_s3_class(dittoDimHex(object=seurat, disc,
+    expect_s3_class(dittoDimHex(object=sce, disc,
         color.method = "max"),
         "ggplot")
-    expect_s3_class(dittoDimHex(object=seurat, disc),
+    expect_s3_class(dittoDimHex(object=sce, disc),
         "ggplot")
     
-    expect_error(dittoDimHex(object=seurat, disc,
+    expect_error(dittoDimHex(object=sce, disc,
         color.method = "abcde"),
         "'color.method' not valid", fixed = TRUE)
 })
 
 test_that("DimHex - color.method options work for continuous data, and defaults to 'median'", {
     ### Manual: First should have lower max color than second
-    expect_s3_class(dittoDimHex(object=seurat, cont,
+    expect_s3_class(dittoDimHex(object=sce, cont,
         color.method = "max"),
         "ggplot")
-    expect_s3_class(dittoDimHex(object=seurat, cont,
+    expect_s3_class(dittoDimHex(object=sce, cont,
         color.method = "sum"),
         "ggplot")
     
     ### Manual: Next 2 should be the same plot
-    expect_s3_class(dittoDimHex(object=seurat, cont,
+    expect_s3_class(dittoDimHex(object=sce, cont,
         color.method = "median"),
         "ggplot")
-    expect_s3_class(dittoDimHex(object=seurat, cont),
+    expect_s3_class(dittoDimHex(object=sce, cont),
         "ggplot")
     
-    expect_error(dittoDimHex(object=seurat, cont,
+    expect_error(dittoDimHex(object=sce, cont,
         color.method = "abcde"),
         "'color.method' not valid", fixed = TRUE)
 })
 
 test_that("DimHex dimensions can be adjusted", {
-    expect_s3_class((p1 <- dittoDimHex(disc, object=seurat, data.out = TRUE,
+    expect_s3_class((p1 <- dittoDimHex(disc, object=sce, data.out = TRUE,
         reduction.use = "PCA"))$plot,
         "ggplot")
     expect_s3_class((p2 <- dittoDimHex(disc, object=sce, data.out = TRUE,
@@ -94,32 +87,32 @@ test_that("DimHex dimensions can be adjusted", {
 })
 
 test_that("dittoDimHexs can be subset to show only certain cells/samples with any cells.use method", {
-    expect_s3_class((c1 <- dittoDimHex(object=seurat, data.out = TRUE,
+    expect_s3_class((c1 <- dittoDimHex(object=sce, data.out = TRUE,
         cells.use = cells.names))$plot,
         "ggplot")
-    expect_s3_class((c2 <- dittoDimHex(object=seurat, data.out = TRUE,
+    expect_s3_class((c2 <- dittoDimHex(object=sce, data.out = TRUE,
         cells.use = cells.logical))$plot,
         "ggplot")
-    expect_s3_class((c3 <- dittoDimHex(object=seurat, data.out = TRUE,
+    expect_s3_class((c3 <- dittoDimHex(object=sce, data.out = TRUE,
         cells.use = 1:40))$plot,
         "ggplot")
     expect_equal(c1$data,c2$data)
     expect_equal(c1$data,c3$data)
     expect_equal(nrow(c3$data), 40)
     # And if we remove an entire grouping...
-    expect_s3_class(dittoDimHex(disc, object=seurat,
-            cells.use = meta(disc,seurat)!=0),
+    expect_s3_class(dittoDimHex(disc, object=sce,
+            cells.use = meta(disc,sce)!=0),
         "ggplot")
 })
 
 test_that("dittoDimHexs colors can be adjusted for discrete data", {
-    expect_s3_class(dittoDimHex(object=seurat, disc,
+    expect_s3_class(dittoDimHex(object=sce, disc,
         color.panel = cols), "ggplot")
     
     ### Manual check: These two should look the same.
-    expect_s3_class(dittoDimHex(object=seurat, disc,
+    expect_s3_class(dittoDimHex(object=sce, disc,
         color.panel = cols[5:1]), "ggplot")
-    expect_s3_class(dittoDimHex(object=seurat, disc,
+    expect_s3_class(dittoDimHex(object=sce, disc,
         color.panel = cols,
         colors = 5:1), "ggplot")
 })
@@ -127,24 +120,24 @@ test_that("dittoDimHexs colors can be adjusted for discrete data", {
 test_that("dittoDimHexs color legend: groupings can be renamed", {
     
     ### Manual check: color groups should be 1:5 (instead of A:E)
-    expect_s3_class(dittoDimHex(object=seurat, disc,
+    expect_s3_class(dittoDimHex(object=sce, disc,
         rename.color.groups = 1:5), "ggplot")
 })
 
 test_that("dittoDimHexs color scales can be adjusted for continuous color data", {
     
     ### Manual check: Legend range adjusted and black to orange
-    expect_s3_class(dittoDimHex(object=seurat, cont,
+    expect_s3_class(dittoDimHex(object=sce, cont,
         min = -5, max = 150, min.color = "black", max.color = "orange"),
         "ggplot")
     
     ### Manual check: Legend has breaaks at all tens in 10 to 60
-    expect_s3_class(dittoDimHex(object=seurat, cont,
+    expect_s3_class(dittoDimHex(object=sce, cont,
         legend.color.breaks = seq(10,60,10)),
         "ggplot")
     
     ### Manual check: Plot looks similar to above except from "WOW", 2:5, to "HEY"
-    expect_s3_class(dittoDimHex(object=seurat, cont,
+    expect_s3_class(dittoDimHex(object=sce, cont,
         legend.color.breaks = seq(10,60,10),
         legend.color.breaks.labels = c("WOW",2:5,"HEY!")),
         "ggplot")
@@ -153,17 +146,17 @@ test_that("dittoDimHexs color scales can be adjusted for continuous color data",
 test_that("dittoDimHexs color scales can be adjusted for density (color)", {
     
     ### Manual check: Legend range adjusted and black to orange
-    expect_s3_class(dittoDimHex(object=seurat,
+    expect_s3_class(dittoDimHex(object=sce,
         min.density = -2, max.density = 2, min.color = "black", max.color = "orange"),
         "ggplot")
     
     ### Manual check: Legend from 1:3
-    expect_s3_class(dittoDimHex(object=seurat,
+    expect_s3_class(dittoDimHex(object=sce,
         legend.density.breaks = seq(1:3)),
         "ggplot")
     
     ### Manual check: Plot looks similar to above except from "WOW", 2, to "HEY"
-    expect_s3_class(dittoDimHex(object=seurat,
+    expect_s3_class(dittoDimHex(object=sce,
         legend.density.breaks = seq(1:3),
         legend.density.breaks.labels = c("WOW",2,"HEY!")),
         "ggplot")
@@ -172,17 +165,17 @@ test_that("dittoDimHexs color scales can be adjusted for density (color)", {
 test_that("dittoDimHexs color scales can be adjusted for density (opacity)", {
     
     ### Manual check: Opacity legend range adjusted -2 to 2 & barely any different
-    expect_s3_class(dittoDimHex(object=seurat, cont,
+    expect_s3_class(dittoDimHex(object=sce, cont,
         min.density = -2, max.density = 2, min.opacity = 0.5, max.opacity = 0.6),
         "ggplot")
     
     ### Manual check: Opacity legend breaks only at 1 and 3
-    expect_s3_class(dittoDimHex(object=seurat, cont,
+    expect_s3_class(dittoDimHex(object=sce, cont,
         legend.density.breaks = c(1,3)),
         "ggplot")
     
     ### Manual check: Opaacity legend from "WOW", 2, to "HEY"
-    expect_s3_class(dittoDimHex(object=seurat, cont,
+    expect_s3_class(dittoDimHex(object=sce, cont,
         legend.density.breaks = seq(1:3),
         legend.density.breaks.labels = c("WOW",2,"HEY!")),
         "ggplot")
@@ -193,7 +186,7 @@ test_that("dittoDimHexs titles and theme can be adjusted", {
     ### Manual check: All titles should be adjusted.
     expect_s3_class(
         dittoDimHex(
-            cont, object=seurat,
+            cont, object=sce,
             main = "Gotta catch", sub = "em all",
             xlab = "Pokemon", ylab = "Pokedex #s",
             legend.color.title = "groups",
@@ -203,31 +196,31 @@ test_that("dittoDimHexs titles and theme can be adjusted", {
     ### Manual check: density legend (color)  = Encounters
     expect_s3_class(
         dittoDimHex(
-            object=seurat,
+            object=sce,
             legend.density.title = "Encounters"),
         "ggplot")
     
     ### Manual check: top and right plot outline removed
-    expect_s3_class(dittoDimHex(cont, object=seurat,
+    expect_s3_class(dittoDimHex(cont, object=sce,
         theme = theme_classic()),
         "ggplot")
     
     ### Manual Check: Numbers should be removed from the axes
-    expect_s3_class(dittoDimHex(disc, object=seurat,
+    expect_s3_class(dittoDimHex(disc, object=sce,
         show.axes.numbers = FALSE),
         "ggplot")
     
     ### Manual Check: Legend removed
-    expect_s3_class(dittoDimHex(object=seurat,
+    expect_s3_class(dittoDimHex(object=sce,
         legend.show = FALSE),
         "ggplot")
 })
 
 test_that("dittoDimHex can add extra vars to dataframe", {
-    df1 <- dittoDimHex(object=seurat,
+    df1 <- dittoDimHex(object=sce,
             data.out = TRUE)$data
     expect_s3_class(
-        df2 <- dittoDimHex(object=seurat,
+        df2 <- dittoDimHex(object=sce,
             extra.vars = c(gene, disc2), data.out = TRUE)$data,
         "data.frame")
     expect_equal(ncol(df1), 2)
@@ -239,14 +232,14 @@ test_that("dittoDimHex can be faceted with split.by (1 or 2 vars)", {
     # MANUAL CHECK: FACETING
     expect_s3_class(
         dittoDimHex(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2),
         "ggplot")
     
     # MANUAL CHECK: horizontal faceting
     expect_s3_class(
         dittoDimHex(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             split.nrow = 1),
         "ggplot")
@@ -254,7 +247,7 @@ test_that("dittoDimHex can be faceted with split.by (1 or 2 vars)", {
     # MANUAL CHECK: vertical faceting
     expect_s3_class(
         dittoDimHex(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = disc2,
             split.ncol = 1),
         "ggplot")
@@ -262,13 +255,13 @@ test_that("dittoDimHex can be faceted with split.by (1 or 2 vars)", {
     # MANUAL CHECK: Grid with rows=age, cols=groups
     expect_s3_class(
         dittoDimHex(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc)),
         "ggplot")
     
     expect_s3_class(
         dittoDimHex(
-            disc, object=seurat,
+            disc, object=sce,
             split.by = c(disc2,disc),
             cells.use = cells.logical),
         "ggplot")
@@ -281,7 +274,7 @@ test_that("dittoDimHex can be faceted with split.by (1 or 2 vars)", {
 test_that("dittoDimHex trajectory adding works", {
     expect_s3_class(
         dittoDimHex(
-            object=seurat, cont,
+            object=sce, cont,
             add.trajectory.lineages = list(
                 c("B","A","C"),
                 c("C","A")),
@@ -291,7 +284,7 @@ test_that("dittoDimHex trajectory adding works", {
     ### Manual Check: One large arrow.
     expect_s3_class(
         dittoDimHex(
-            object=seurat, cont,
+            object=sce, cont,
             add.trajectory.lineages = list(
                 c("C","A")),
             trajectory.cluster.meta = disc,
@@ -301,7 +294,7 @@ test_that("dittoDimHex trajectory adding works", {
     ### Manual Check: Arrows should be detached from points
     expect_s3_class(
         dittoDimHex(
-            disc, object=seurat,
+            disc, object=sce,
             add.trajectory.curves = list(
                 data.frame(
                     c(-10,0,-20),
@@ -316,7 +309,7 @@ test_that("dittoDimHex trajectory adding works", {
 test_that("dittoScatterHex trajectory curve adding works", {
     expect_s3_class(
         dittoScatterHex(
-            gene, cont, gene, object=seurat,
+            gene, cont, gene, object=sce,
             add.trajectory.curves = list(
                 data.frame(
                     c(-10,0,-20),
@@ -329,12 +322,12 @@ test_that("dittoScatterHex trajectory curve adding works", {
 })
 
 test_that("dittoDimHex adding contours", {
-    expect_s3_class(dittoDimHex(object=seurat, disc,
+    expect_s3_class(dittoDimHex(object=sce, disc,
         do.contour = TRUE),
         "ggplot")
     
     ### Manual Check: Contour lines light blue and dashed
-    expect_s3_class(dittoDimHex(object=seurat, disc,
+    expect_s3_class(dittoDimHex(object=sce, disc,
         do.contour = TRUE,
         contour.color = "lightblue", contour.linetype = "dashed"),
         "ggplot")
@@ -343,26 +336,26 @@ test_that("dittoDimHex adding contours", {
 test_that("dittoDimHex do.label/do.ellipse", {
     expect_s3_class(
         dittoDimHex(
-            disc, object=seurat,
+            disc, object=sce,
             do.label = TRUE),
         "ggplot")
     expect_s3_class(
         dittoDimHex(
-            disc, object=seurat,
+            disc, object=sce,
             do.ellipse = TRUE),
         "ggplot")
 })
 
 test_that("dittoDimHex ignores do.label/do.ellipse for continuous data", {
-    expect_message(dittoDimHex(object=seurat, cont,
+    expect_message(dittoDimHex(object=sce, cont,
         do.label = TRUE),
         "do.label was/were ignored for non-discrete data", fixed = TRUE)
-    expect_message(dittoDimHex(object=seurat, cont,
+    expect_message(dittoDimHex(object=sce, cont,
         do.ellipse = TRUE),
         "do.ellipse was/were ignored for non-discrete data", fixed = TRUE)
     
     # No message for discrete data && MANUAAL CHECK: ellipse is drawn 
-    expect_message(dittoDimHex(object=seurat, disc,
+    expect_message(dittoDimHex(object=sce, disc,
         do.ellipse = TRUE),
         NA)
 })
@@ -372,11 +365,11 @@ test_that("dittoDimHex ignores do.label/do.ellipse for continuous data", {
 # Addition checks for Scatter
 ##########
 
-# assay/slot/adjustment Scatter
+# assay/adjustment Scatter
 test_that("dittoScatterHex gene display can utilize different data.types (excluding for hover)", {
-    expect_s3_class((p <- dittoScatterHex(gene, gene, gene, object = seurat, data.out = TRUE,
-        slot.x = "counts",
-        slot.y = "counts",
+    expect_s3_class((p <- dittoScatterHex(gene, gene, gene, object = sce, data.out = TRUE,
+        assay.x = "counts",
+        assay.y = "counts",
         adjustment.color = "z-score"))$plot, "ggplot")
     expect_equal(
         p$data$X,
@@ -384,12 +377,6 @@ test_that("dittoScatterHex gene display can utilize different data.types (exclud
     expect_equal(
         mean(p$data$color),
         0)
-    expect_s3_class((p <- dittoScatterHex(gene, gene, gene, object = sce, data.out = TRUE,
-        assay.x = "counts",
-        assay.y = "counts"))$plot, "ggplot")
-    expect_equal(
-        p$data$X,
-        round(p$data$Y,0))
     expect_s3_class((p <- dittoScatterHex(gene, gene, gene, object = sce, data.out = TRUE,
         adjustment.y= "relative.to.max"))$plot, "ggplot")
     expect_equal(

--- a/tests/testthat/test-Plot.R
+++ b/tests/testthat/test-Plot.R
@@ -1,45 +1,37 @@
 # Tests for dittoPlot function
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-Plot.R")
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
-seurat$all <- "A"
+sce$number <- as.numeric(seq_along(colnames(sce)))
+sce$all <- "A"
 grp <- "clusters"
 clr <- "age"
 clr2 <- "groups"
 gene1 <- "gene1"
-cells.names <- colnames(seurat)[1:40]
+cells.names <- colnames(sce)[1:40]
 cells.logical <- c(rep(TRUE, 40), rep(FALSE,ncells-40))
 
 test_that("dittoPlot can plot continuous metadata with all plot types", {
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter")),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("ridgeplot", "jitter")),
-        "ggplot")
-})
-
-test_that("dittoPlot can work for SCE", {
-    expect_s3_class(
-        dittoPlot(
-            gene1, object=sce, group.by = grp,
-            plots = c("vlnplot", "boxplot", "jitter")),
         "ggplot")
 })
 
 test_that("dittoPlot can plot gene expression data with all plot types", {
     expect_s3_class(
         dittoPlot(
-            gene1, object=seurat, group.by = grp,
+            gene1, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter")),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            gene1, object=seurat, group.by = grp,
+            gene1, object=sce, group.by = grp,
             plots = c("ridgeplot", "jitter")),
         "ggplot")
 })
@@ -47,21 +39,21 @@ test_that("dittoPlot can plot gene expression data with all plot types", {
 test_that("dittoPlots can be subset to show only certain cells/samples with any cells.use method", {
     expect_s3_class(
         {c1 <- dittoPlot(
-            "number", object=seurat, group.by = grp, data.out = TRUE,
+            "number", object=sce, group.by = grp, data.out = TRUE,
             plots = c("vlnplot", "boxplot"),
             cells.use = cells.names)
         c1$p},
         "ggplot")
     expect_s3_class(
         {c2 <- dittoPlot(
-            "number", object=seurat, group.by = grp, data.out = TRUE,
+            "number", object=sce, group.by = grp, data.out = TRUE,
             plots = c("vlnplot", "boxplot"),
             cells.use = cells.logical)
         c2$p},
         "ggplot")
     expect_s3_class(
         {c3 <- dittoPlot(
-            "number", object=seurat, group.by = grp, data.out = TRUE,
+            "number", object=sce, group.by = grp, data.out = TRUE,
             plots = c("vlnplot", "boxplot"),
             cells.use = 1:40)
         c3$p},
@@ -71,16 +63,16 @@ test_that("dittoPlots can be subset to show only certain cells/samples with any 
     # And if we remove an entire grouping...
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot"),
-            cells.use = meta(grp,seurat)!=0),
+            cells.use = meta(grp,sce)!=0),
         "ggplot")
 })
 
 test_that("dittoPlot main legend can be removed", {
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             legend.show = FALSE),
         "ggplot")
 })
@@ -88,13 +80,13 @@ test_that("dittoPlot main legend can be removed", {
 test_that("dittoPlot colors can be distinct from group.by", {
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             color.by = clr),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             color.by = clr2),
         "ggplot")
@@ -103,13 +95,13 @@ test_that("dittoPlot colors can be distinct from group.by", {
 test_that("dittoPlot shapes can be a metadata and distinct from group.by", {
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             shape.by = grp),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             shape.by = clr2),
         "ggplot")
@@ -119,28 +111,28 @@ test_that("dittoPlot shapes can be adjusted in many ways", {
     # Shapes should be triangles instead of dots
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             shape.panel = 17),
         "ggplot")
     # Shapes should be dot and triangle instead of dot and square
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             shape.by = clr2, shape.panel = 16:19),
         "ggplot")
     # Shapes should be enlarged in the legend
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             shape.by = clr2, jitter.shape.legend.size = 5),
         "ggplot")
     # Shapes legend should be removed
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             shape.by = clr2, jitter.shape.legend.show = FALSE),
         "ggplot")
@@ -150,13 +142,13 @@ test_that("dittoPlots colors can be adjusted", {
     ### Manual check: These two should look the same.
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot"),
             color.panel = dittoColors()[5:1]),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot"),
             colors = 5:1),
         "ggplot")
@@ -166,7 +158,7 @@ test_that("dittoPlots titles and theme can be adjusted", {
     ### Manual check: All titles should be adjusted.
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             main = "Gotta catch", sub = "em all",
             xlab = "Pokemon", ylab = "Pokedex #s",
             legend.title = "groups"),
@@ -174,75 +166,75 @@ test_that("dittoPlots titles and theme can be adjusted", {
     ### Manual check: plot should be boxed
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             theme = theme_bw()),
         "ggplot")
 })
 
-test_that("dittoPlots y-axis can be adjusted, x for ridgeplots", {
+test_that("dittoPlots y-axis can be adjusted, (x for ridgeplots)", {
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             min = -5, max = 100),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             y.breaks = seq(10,60,10)),
         "ggplot")
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             min = -50, max = 100),
         "ggplot")
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             y.breaks = seq(10,60,10)),
         "ggplot")
 })
 
-test_that("dittoPlots x-labels can be adjusted, (y) for ridgeplots", {
+test_that("dittoPlots x-labels can be adjusted, (y for ridgeplots)", {
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             x.labels = 5:8),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             x.reorder = 4:1),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             x.labels.rotate = FALSE),
         "ggplot")
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             x.labels = 5:8),
         "ggplot")
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             x.reorder = 4:1),
         "ggplot")
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             x.labels.rotate = FALSE),
         "ggplot")
     ### Manual Check: L->R, green(5), blue(6), orange(7), with horizontal labels
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             x.labels = 5:8, x.reorder = 4:1, x.labels.rotate = FALSE),
         "ggplot")
     ### Manual Check: B -> T, green(5), blue(6), orange(7), with rotated labels
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             x.labels = 5:8, x.reorder = 4:1, x.labels.rotate = TRUE),
         "ggplot")
 })
@@ -250,17 +242,17 @@ test_that("dittoPlots x-labels can be adjusted, (y) for ridgeplots", {
 test_that("dittoPlot can have lines added", {
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             add.line = 20),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             add.line = 20, line.linetype = "solid", line.color = "green"),
         "ggplot")
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             add.line = 20, line.linetype = "solid", line.color = "green"),
         "ggplot")
 })
@@ -269,12 +261,12 @@ test_that("dittoPlot jitter adjustments work", {
     # Manuel Check: Large blue dots that, in the y-plot, look continuous across groups.
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp, plots = "jitter",
+            "number", object=sce, group.by = grp, plots = "jitter",
             jitter.size = 10, jitter.color = "blue", jitter.width = 1),
         "ggplot")
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp, plots = c("jitter","ridgeplot"),
+            "number", object=sce, group.by = grp, plots = c("jitter","ridgeplot"),
             jitter.size = 10, jitter.color = "blue", jitter.width = 1),
         "ggplot")
     
@@ -286,7 +278,7 @@ test_that("dittoPlot jitter adjustments work", {
     # 1. Defaults
     expect_s3_class(
         print(dittoPlot(
-            "number", object=seurat, group.by = "all",
+            "number", object=sce, group.by = "all",
             color.by = clr2, plots = c("vlnplot", "boxplot", "jitter"),
             shape.panel = 21, jitter.size = 2, vlnplot.scaling = "width")),
         "ggplot")
@@ -294,7 +286,7 @@ test_that("dittoPlot jitter adjustments work", {
     # 2. jitters further apart
     expect_s3_class(
         print(dittoPlot(
-            "number", object=seurat, group.by = "all",
+            "number", object=sce, group.by = "all",
             color.by = clr2, plots = c("vlnplot", "boxplot", "jitter"),
             shape.panel = 21, jitter.size = 2, vlnplot.scaling = "width",
             jitter.position.dodge = 2)),
@@ -303,7 +295,7 @@ test_that("dittoPlot jitter adjustments work", {
     # 3. set by boxplot dodge... only aligned with boxplots
     expect_s3_class(
         print(dittoPlot(
-            "number", object=seurat, group.by = "all",
+            "number", object=sce, group.by = "all",
             color.by = clr2, plots = c("vlnplot", "boxplot", "jitter"),
             shape.panel = 21, jitter.size = 2, vlnplot.scaling = "width",
             boxplot.position.dodge = 2)),
@@ -312,7 +304,7 @@ test_that("dittoPlot jitter adjustments work", {
     # 4. set by vlnplot.width
     expect_s3_class(
         print(dittoPlot(
-            "number", object=seurat, group.by = "all",
+            "number", object=sce, group.by = "all",
             color.by = clr2, plots = c("vlnplot", "boxplot", "jitter"),
             shape.panel = 21, jitter.size = 2, vlnplot.scaling = "width",
             vlnplot.width = 0.5,
@@ -325,14 +317,14 @@ test_that("dittoPlot boxplot adjustments work", {
     # Not actually checked here manually: whether outliers are shown cuz there are none.
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp, plots = c("jitter", "boxplot"),
+            "number", object=sce, group.by = grp, plots = c("jitter", "boxplot"),
             boxplot.width = 1, boxplot.color = "blue", boxplot.fill = FALSE,
             boxplot.show.outliers = TRUE),
         "ggplot")
     # Manual Check: boxplots that overlap, with thick lines
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp, plots = c("jitter","boxplot"),
+            "number", object=sce, group.by = grp, plots = c("jitter","boxplot"),
             color.by = clr,
             boxplot.width = 0.4, boxplot.position.dodge = 0.2,
             boxplot.lineweight = 2),
@@ -343,23 +335,23 @@ test_that("dittoPlot violin plot adjustments work", {
     # Manuel Check: Almost non-existent lines, with quite overlapping vlns.
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             vlnplot.lineweight = 0.1, vlnplot.width = 5),
         "ggplot")
     # The next three should look different from eachother:
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             vlnplot.scaling = "count"),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             vlnplot.scaling = "area"),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             vlnplot.scaling = "width"),
         "ggplot")
 })
@@ -368,31 +360,31 @@ test_that("dittoPlot ridgeplot adjustments work", {
     # Manuel Check: Almost non-existent lines, with quite overlapping ridges.
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             ridgeplot.lineweight = 0.1, ridgeplot.scale = 5),
         "ggplot")
     # Manual Check: Lots of space at the top.
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             ridgeplot.ymax.expansion = 5),
         "ggplot")
     # Manual Check: Histogram
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             ridgeplot.shape = "hist"),
         "ggplot")
     # Manual Check: Hist with narrower bins
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             ridgeplot.shape = "hist", ridgeplot.bins = 60),
         "ggplot")
     # Manual Check: Hist with even narrower bins
     expect_s3_class(
         dittoRidgePlot(
-            "number", object=seurat, group.by = grp,
+            "number", object=sce, group.by = grp,
             ridgeplot.shape = "hist", ridgeplot.bins = 60,
             ridgeplot.binwidth = 1),
         "ggplot")
@@ -400,11 +392,11 @@ test_that("dittoPlot ridgeplot adjustments work", {
 
 test_that("dittoPlot can add extra vars to dataframe", {
     df1 <- dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             data.out = TRUE)[[2]]
     expect_s3_class(
         df2 <- dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             extra.vars = c(clr, clr2), data.out = TRUE)[[2]],
         "data.frame")
     expect_equal(ncol(df1), 3)
@@ -415,33 +407,33 @@ test_that("dittoPlot can be facted with split.by (1 or 2 vars)", {
     # MANUAL CHECK: FACETING
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             split.by = grp),
         "ggplot")
     # horizontal
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             split.by = grp,
             split.nrow = 1),
         "ggplot")
     # vertical
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             split.by = grp,
             split.ncol = 1),
         "ggplot")
     # Grid with rows=age, cols=groups
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             split.by = c(grp,clr)),
         "ggplot")
     # Works with cells.use (should have grey cells)
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             split.by = c(grp,clr),
             cells.use = cells.logical),
         "ggplot")
@@ -451,29 +443,29 @@ test_that("dittoPlot with and without jitter rasterization produces identical pl
     # MANUAL CHECK: Should be indentical
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             do.raster = TRUE),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat),
+            gene1, grp, grp, object = sce),
         "ggplot")
     # Jitter in front.
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             do.raster = TRUE, 
             plots = c("vlnplot", "jitter")),
         "ggplot")
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat, 
+            gene1, grp, grp, object = sce, 
             plots = c("vlnplot", "jitter")),
         "ggplot")
     # Should be lower resolution
     expect_s3_class(
         dittoPlot(
-            gene1, grp, grp, object = seurat,
+            gene1, grp, grp, object = sce,
             do.raster = TRUE,
             raster.dpi = 10,
             plots = c("vlnplot", "jitter")),
@@ -485,3 +477,5 @@ test_that("dittoPlot swap.rownames works", {
         dittoPlot(sce, "gene1_symb", grp, swap.rownames = "symbol"),
         "ggplot")
 })
+
+## For Future: Could add checking of assay/slot/adjustments

--- a/tests/testthat/test-PlotVarsAcrossGroups.R
+++ b/tests/testthat/test-PlotVarsAcrossGroups.R
@@ -1,83 +1,64 @@
 # Tests for dittoPlotVarsAcrossGroups function
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-PlotVarsAcrossGroups.R")
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
-seurat$number2 <- as.numeric(seq_along(colnames(seurat)))
-seurat$half <- c(rep("a", 40), rep("b", ncells-40))
-seurat$quarter <- seurat$half
-seurat$quarter[21:40] <- "c"
-seurat$quarter[51:ncells] <- "d"
+sce$number <- as.numeric(seq_along(colnames(sce)))
+sce$number2 <- as.numeric(seq_along(colnames(sce)))
+sce$half <- c(rep("a", 40), rep("b", ncells-40))
+sce$quarter <- sce$half
+sce$quarter[21:40] <- "c"
+sce$quarter[51:ncells] <- "d"
 grp.c <- "quarter"
 clr.g <- "half"
-genes <- getGenes(seurat)[1:5]
+genes <- getGenes(sce)[1:5]
 grp <- "groups"
 clr <- "clusters"
 clr2 <- "age"
-cells.names <- colnames(seurat)[1:40]
+cells.names <- colnames(sce)[1:40]
 cells.logical <- c(rep(TRUE, 40), rep(FALSE,ncells-40))
 
 test_that("dittoPlotVarsAcrossGroups can plot continuous data with all plot types", {
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter")),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("ridgeplot", "jitter")),
-        "ggplot")
-})
-
-test_that("dittoPlotVarsAcrossGroups can work for SE and RNAseq", {
-    expect_s3_class(
-        dittoPlotVarsAcrossGroups(
-            genes, object=sce, group.by = grp),
-        "ggplot")
-})
-
-test_that("dittoPlotVarsAcrossGroups can work for metadata", {
-    expect_s3_class(
-        dittoPlotVarsAcrossGroups(seurat, group.by = grp,
-            c("number","number2")),
-        "ggplot")
-    
-    expect_s3_class(
-        dittoPlotVarsAcrossGroups(seurat, group.by = grp,
-            c("number", "gene1")),
         "ggplot")
 })
 
 test_that("dittoPlotVarsAcrossGroups works with any gene adjustments", {
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             adjustment = "relative.to.max"),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             adjustment = "z-score"),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             adjustment = NULL),
         "ggplot")
 })
 
 test_that("dittoPlotVarsAcrossGroups errors for single vars or non-numeric vars", {
     expect_error(
-        dittoPlotVarsAcrossGroups(seurat, group.by = grp,
+        dittoPlotVarsAcrossGroups(sce, group.by = grp,
             c("number")),
         "'vars' must be a vector of at least two", fixed = TRUE)
     
     expect_error(
-        dittoPlotVarsAcrossGroups(seurat, group.by = grp,
+        dittoPlotVarsAcrossGroups(sce, group.by = grp,
             c("gene1")),
         "'vars' must be a vector of at least two", fixed = TRUE)
     expect_error(
-        dittoPlotVarsAcrossGroups(seurat, group.by = grp,
+        dittoPlotVarsAcrossGroups(sce, group.by = grp,
             c("gene1", "gene2", grp)),
         "'vars' must be numeric", fixed = TRUE)
 })
@@ -85,7 +66,7 @@ test_that("dittoPlotVarsAcrossGroups errors for single vars or non-numeric vars"
 test_that("dittoPlotVarsAcrossGroups can work for metadata", {
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            c("number","number2"), object=seurat, group.by = grp),
+            c("number","number2"), object=sce, group.by = grp),
         "ggplot")
 })
 
@@ -93,7 +74,7 @@ test_that("dittoPlotVarsAcrossGroups can work for metadata", {
 test_that("dittoPlotVarsAcrossGroups main legend can be removed", {
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             legend.show = FALSE),
         "ggplot")
 })
@@ -101,13 +82,13 @@ test_that("dittoPlotVarsAcrossGroups main legend can be removed", {
 test_that("dittoPlotVarsAcrossGroups colors can be distinct from group.by", {
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp.c,
+            genes, object=sce, group.by = grp.c,
             plots = c("vlnplot", "boxplot", "jitter"),
             color.by = clr.g),
         "ggplot")
     expect_error(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             color.by = clr2),
         "Unable to interpret 'color.by' input.", fixed = TRUE)
@@ -116,13 +97,13 @@ test_that("dittoPlotVarsAcrossGroups colors can be distinct from group.by", {
 test_that("dittoPlotVarsAcrossGroups summary.fxn can be adjusted", {
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             summary.fxn = median),
         "ggplot")
     expect_error(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"),
             summary.fxn = function(x) x/2),
         NULL)
@@ -131,21 +112,21 @@ test_that("dittoPlotVarsAcrossGroups summary.fxn can be adjusted", {
 test_that("dittoPlotsVarsAcrossGroups can be subset to show only certain cells/samples with any cells.use method", {
     expect_s3_class(
         {c1 <- dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp, data.out = TRUE,
+            genes, object=sce, group.by = grp, data.out = TRUE,
             plots = c("vlnplot", "boxplot"),
             cells.use = cells.names)
         c1$p},
         "ggplot")
     expect_s3_class(
         {c2 <- dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp, data.out = TRUE,
+            genes, object=sce, group.by = grp, data.out = TRUE,
             plots = c("vlnplot", "boxplot"),
             cells.use = cells.logical)
         c2$p},
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot"),
             cells.use = 1:40),
         "ggplot")
@@ -153,9 +134,9 @@ test_that("dittoPlotsVarsAcrossGroups can be subset to show only certain cells/s
     # And if we remove an entire grouping...
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot"),
-            cells.use = meta(grp,seurat)!=0),
+            cells.use = meta(grp,sce)!=0),
         "ggplot")
 })
 
@@ -163,13 +144,13 @@ test_that("dittoPlots colors can be adjusted", {
     ### Manual check: These two should look the same.
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot"),
             color.panel = dittoColors()[5:1]),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot"),
             colors = 5:1),
         "ggplot")
@@ -179,7 +160,7 @@ test_that("dittoPlots titles and theme can be adjusted", {
     ### Manual check: All titles should be adjusted.
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             main = "Gotta catch", sub = "em all",
             xlab = "Pokemon", ylab = "Pokedex #s",
             legend.title = "groups"),
@@ -187,54 +168,54 @@ test_that("dittoPlots titles and theme can be adjusted", {
     ### Manual check: plot should be boxed
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             theme = theme_bw()),
         "ggplot")
 })
 
-test_that("dittoPlots y-axis can be adjusted, x for ridgeplots", {
+test_that("dittoPlots y-axis can be adjusted, (x for ridgeplots)", {
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             min = -5, max = 100),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             y.breaks = seq(10,60,10)),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             min = -2, max = 1, plots = c("ridgeplot","jitter")),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             y.breaks = seq(-1,1.5,0.1), plots = c("ridgeplot","jitter")),
         "ggplot")
 })
 
-test_that("dittoPlots x-labels can be adjusted, (y) for ridgeplots", {
+test_that("dittoPlots x-labels can be adjusted, (y for ridgeplots)", {
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             x.labels = 3:7),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             x.reorder = 5:1),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             x.labels.rotate = FALSE),
         "ggplot")
     ### Manual Check: L->R, green(5), blue(6), orange(7), with horizontal labels
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             x.labels = 3:7, x.reorder = 5:1, x.labels.rotate = FALSE),
         "ggplot")
 })
@@ -243,12 +224,12 @@ test_that("dittoPlotVarsAcrossGroups can have lines added", {
     # Manuel Check: Large blue dots that, in the yplot, look continuous accross groups.
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             add.line = 0),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             add.line = 0, line.linetype = "solid", line.color = "green"),
         "ggplot")
 })
@@ -257,7 +238,7 @@ test_that("dittoPlotVarsAcrossGroups jitter adjustments work", {
     # Manuel Check: Large blue dots that, in the yplot, look continuous accross groups.
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp, plots = "jitter",
+            genes, object=sce, group.by = grp, plots = "jitter",
             jitter.size = 10, jitter.color = "blue", jitter.width = 1),
         "ggplot")
 })
@@ -266,13 +247,13 @@ test_that("dittoPlotVarsAcrossGroups boxplot adjustments work", {
     # Manuel Check: Blue boxplots that touch eachother, with jitter visible behind in first plot, outliers shown in second
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp, plots = c("jitter", "boxplot"),
+            genes, object=sce, group.by = grp, plots = c("jitter", "boxplot"),
             boxplot.width = 1, boxplot.color = "blue", boxplot.fill = FALSE,
             boxplot.show.outliers = TRUE),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp, plots = c("jitter", "boxplot"),
+            genes, object=sce, group.by = grp, plots = c("jitter", "boxplot"),
             boxplot.width = 1, boxplot.color = "blue",
             boxplot.show.outliers = TRUE),
         "ggplot")
@@ -282,23 +263,23 @@ test_that("dittoPlotVarsAcrossGroups violin plot adjustments work", {
     # Manuel Check: Almost non-existent lines, with quite overlapping vlns.
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             vlnplot.lineweight = 0.1, vlnplot.width = 5),
         "ggplot")
     # The next three: first two look the same because equal numbers of dots, third should look different:
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             vlnplot.scaling = "count"),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             vlnplot.scaling = "area"),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             vlnplot.scaling = "width"),
         "ggplot")
 })
@@ -306,12 +287,12 @@ test_that("dittoPlotVarsAcrossGroups violin plot adjustments work", {
 test_that("dittoPlotVarsAcrossGroups with and without jitter rasterization produces identical plots", {
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter"), do.raster = TRUE),
         "ggplot")
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            genes, object=seurat, group.by = grp,
+            genes, object=sce, group.by = grp,
             plots = c("vlnplot", "boxplot", "jitter")),
         "ggplot")
 })
@@ -363,3 +344,5 @@ test_that("dittoPlotVarsAcrossGroups split.by works", {
         split2$p,
         "ggplot")
 })
+
+## For Future: Could add checking of assay/slot/adjustments

--- a/tests/testthat/test-ScatterPlot.R
+++ b/tests/testthat/test-ScatterPlot.R
@@ -5,19 +5,19 @@
 #### Most ScatterPlot features are used/tested in the test-DimPlot, so this will look light.
 ####
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
+sce$number <- as.numeric(seq_along(colnames(sce)))
 gene <- "gene1"
 cont <- "number"
 disc <- "groups"
 disc2 <- "age"
-cells.names <- colnames(seurat)[1:40]
+cells.names <- colnames(sce)[1:40]
 cells.logical <- c(rep(TRUE, 40), rep(FALSE,ncells-40))
 cols <- c("red", "blue", "yellow", "green", "black", "gray", "white")
 
-test_that("dittoScatterPlot can plot genes or metadata & work for SCE", {
+test_that("dittoScatterPlot can plot genes or metadata & works for SCE", {
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, object = seurat),
+            gene, cont, object = sce),
         "ggplot")
     expect_s3_class(
         dittoScatterPlot(
@@ -28,34 +28,34 @@ test_that("dittoScatterPlot can plot genes or metadata & work for SCE", {
 test_that("dittoScatterPlot can overlay colors, continuous or discrete", {
     expect_true(
         "color" %in%
-        names(dittoScatterPlot(gene, cont, cont, object = seurat, data.out = TRUE)$Target_data))
+        names(dittoScatterPlot(gene, cont, cont, object = sce, data.out = TRUE)$Target_data))
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, cont, object = seurat),
+            gene, cont, cont, object = sce),
         "ggplot")
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, disc, object = seurat),
+            gene, cont, disc, object = sce),
         "ggplot")
 })
 
 test_that("dittoScatterPlot can overlay shapes", {
     expect_true(
         "shape" %in%
-        names(dittoScatterPlot(gene, cont, NULL, disc, object = seurat, data.out = TRUE)$Target_data))
+        names(dittoScatterPlot(gene, cont, NULL, disc, object = sce, data.out = TRUE)$Target_data))
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, NULL, disc, object = seurat),
+            gene, cont, NULL, disc, object = sce),
         "ggplot")
 })
 
 test_that("dittoScatterPlot can add extra vars to dataframe", {
     df1 <- dittoScatterPlot(
-            gene, cont, NULL, disc, object = seurat,
+            gene, cont, NULL, disc, object = sce,
             data.out = TRUE)[[2]]
     expect_s3_class(
         df2 <- dittoScatterPlot(
-            gene, cont, NULL, disc, object = seurat,
+            gene, cont, NULL, disc, object = sce,
             extra.vars = c(gene, disc2), data.out = TRUE)[[2]],
         "data.frame")
     expect_equal(ncol(df1), 3)
@@ -63,9 +63,9 @@ test_that("dittoScatterPlot can add extra vars to dataframe", {
 })
 
 test_that("dittoScatterPlot gene display can utilize different data.types (excluding for hover)", {
-    df <- dittoScatterPlot(gene, gene, gene, NULL, object = seurat,
-        slot.x = "counts",
-        slot.y = "counts",
+    df <- dittoScatterPlot(gene, gene, gene, NULL, object = sce,
+        assay.x = "counts",
+        assay.y = "counts",
         adjustment.color = "z-score",
         data.out = TRUE)
     expect_equal(
@@ -74,13 +74,6 @@ test_that("dittoScatterPlot gene display can utilize different data.types (exclu
     expect_equal(
         mean(df$Target_data$color),
         0)
-    df <- dittoScatterPlot(gene, gene, gene, NULL, object = sce,
-        assay.x = "counts",
-        assay.y = "counts",
-        data.out = TRUE)
-    expect_equal(
-        df$Target_data$X,
-        round(df$Target_data$Y,0))
 })
 
 ####################
@@ -91,33 +84,33 @@ test_that("dittoScatterPlot can be faceted with split.by (1 or 2 vars)", {
     # MANUAL CHECK: FACETING
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, NULL, disc, object = seurat,
+            gene, cont, NULL, disc, object = sce,
             split.by = disc2),
         "ggplot")
     # horizontal
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, NULL, disc, object = seurat,
+            gene, cont, NULL, disc, object = sce,
             split.by = disc2,
             split.nrow = 1),
         "ggplot")
     # vertical
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, NULL, disc, object = seurat,
+            gene, cont, NULL, disc, object = sce,
             split.by = disc2,
             split.ncol = 1),
         "ggplot")
     # Grid with rows=age, cols=groups
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, NULL, disc, object = seurat,
+            gene, cont, NULL, disc, object = sce,
             split.by = c(disc2,disc)),
         "ggplot")
     # Works with cells.use (should have grey cells)
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, NULL, disc, object = seurat,
+            gene, cont, NULL, disc, object = sce,
             split.by = c(disc2,disc),
             cells.use = cells.logical),
         "ggplot")
@@ -127,7 +120,7 @@ test_that("dittoScatterPlot can show trajectory curves", {
     # MANUAL CHECK: Should have arrows overlaid which are detached from data points
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, object=seurat,
+            gene, cont, object=sce,
             add.trajectory.curves = list(
                 data.frame(
                     c(-10,0,-20),
@@ -144,42 +137,42 @@ test_that("dittoScatterPlot with and without rasterization produces identical pl
     # MANUAL CHECK: Should be identical
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, object = seurat, do.raster = TRUE),
+            gene, cont, object = sce, do.raster = TRUE),
         "ggplot")
     expect_s3_class(
         dittoScatterPlot(
-            gene, gene, object = seurat),
+            gene, gene, object = sce),
         "ggplot")
 })
 
 test_that("do.label doesn't cause ignorance of split.by factor level ordering", {
     
     # Set two metadata as factors with non-default levels ordering
-    seurat$groups_rev <- factor(seurat$groups, levels = rev(unique(seurat$groups)))
-    seurat$clusters_rev <- factor(seurat$clusters, levels = 4:1)
+    sce$groups_rev <- factor(sce$groups, levels = rev(unique(sce$groups)))
+    sce$clusters_rev <- factor(sce$clusters, levels = 4:1)
     
     ### MANUAL CHECK: Should be identical aside from the lack of labels in #2 and #4
     # One `split.by`
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, disc, object = seurat,
+            gene, cont, disc, object = sce,
             split.by = "groups_rev", do.label = FALSE),
         "ggplot")
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, disc, object = seurat,
+            gene, cont, disc, object = sce,
             split.by = "groups_rev", do.label = TRUE),
         "ggplot")
     
     # Two `split.by`
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, disc, object = seurat,
+            gene, cont, disc, object = sce,
             split.by = c("groups_rev", "clusters_rev"), do.label = FALSE),
         "ggplot")
     expect_s3_class(
         dittoScatterPlot(
-            gene, cont, disc, object = seurat,
+            gene, cont, disc, object = sce,
             split.by = c("groups_rev", "clusters_rev"), do.label = TRUE),
         "ggplot")
 })

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -3,16 +3,13 @@
 
 sce$number <- as.numeric(seq_along(colnames(sce)))
 
-# Convert
-seurat <- try(Seurat::as.Seurat(sce), silent = FALSE)
-seurat_conversion_worked <- exists("seurat")
+seurat <- suppressWarnings(Seurat::as.Seurat(sce))
 
-# Ensure metadata has row.names (a past issue with the fxn)
+# Ensure metadata has row.names (past issue with the fxn)
 rownames(seurat@meta.data) <- colnames(seurat)
 
 ### TESTS
 test_that("dittoBarPlot works for a Seurat", {
-    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
     expect_s3_class(
         dittoBarPlot(
             seurat, "clusters", group.by = "age"),
@@ -20,12 +17,11 @@ test_that("dittoBarPlot works for a Seurat", {
 })
 
 test_that("importDemux + demux.SNP.summary & demux.calls.summary work for a Seurat", {
-    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
     ### Prep
     sce.noDash <- sce
     colnames(sce.noDash) <- sapply(colnames(sce.noDash), function(X) strsplit(X, "-")[[1]][1])
     # Convert that SCE to Seurat
-    seurat.noDash <- try(Seurat::as.Seurat(sce.noDash), silent = TRUE)
+    seurat.noDash <- suppressWarnings(Seurat::as.Seurat(sce.noDash))
     
     expect_s4_class(
         seurat.demux <- importDemux(

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -1,0 +1,111 @@
+# Tests for functionality with Seurat objects
+# library(dittoSeq); library(testthat); source("setup.R"); source("test-Seurat.R")
+
+# Convert SCE to Seurat
+seurat <- suppressWarnings(Seurat::as.Seurat(sce))
+rownames(seurat@meta.data) <- colnames(seurat)
+
+# For importDemux
+sce.noDash <- sce
+colnames(sce.noDash) <- sapply(colnames(sce.noDash), function(X) strsplit(X, "-")[[1]][1])
+
+seurat.noDash <- suppressWarnings(Seurat::as.Seurat(sce.noDash))
+
+sce.demux <- importDemux(
+  sce.noDash, lane.meta = "groups",
+  demuxlet.best = "mock_demux.best",
+  verbose = FALSE)
+seurat.demux <- suppressWarnings(Seurat::as.Seurat(sce.demux))
+
+best <- read.table(file = "mock_demux.best", header=TRUE, sep="\t", stringsAsFactors = FALSE)
+samples <- vapply(
+  as.character(best$BEST),
+  function(X) strsplit(X,'-')[[1]][2],
+  FUN.VALUE = character(1))[seq_len(ncol(sce))]
+names(samples) <- NULL
+
+### TESTS
+test_that("dittoBarPlot works for a Seurat", {
+  expect_s3_class(
+    dittoBarPlot(
+      seurat, "clusters", group.by = "age"),
+    "ggplot")
+})
+
+test_that("importDemux works for a Seurat", {
+  expect_s4_class(
+    t <- importDemux(
+      object = seurat.noDash, lane.meta = "groups",
+      demuxlet.best = "mock_demux.best"),
+    "Seurat")
+  # All called samples are correct
+  expect_true(all(samples == meta("Sample", t)))
+})
+
+test_that("demux.SNP.summary & demux.calls.summary work for a Seurat", {
+  expect_s3_class(
+    demux.SNP.summary(seurat.demux),
+    "ggplot")
+  expect_s3_class(
+    demux.calls.summary(seurat.demux),
+    "ggplot")
+})
+  
+test_that("dittoDimPlot work for a Seurat & 'slot' input usable", {
+  expect_s3_class(
+    dittoDimPlot(
+      "groups", object=seurat),
+    "ggplot")
+  
+  df <- dittoDimPlot("gene1", object = seurat, data.out = TRUE,
+      slot = "counts")
+  expect_equal(
+    df$Target_data$color,
+    round(df$Target_data$color,0))
+})
+
+test_that("dittoDotPlot works with gene and meta data for a Seurat, with 'slot' doing what it should", {
+  expect_s3_class(
+    print(dittoDotPlot(seurat, group.by = "clusters",
+        getGenes(sce)[1:5])),
+    "ggplot")
+  expect_s3_class(
+    dittoDotPlot(seurat, group.by = "clusters",
+        c("score", "score2", "score3")),
+    "ggplot")
+  expect_s3_class(
+    dittoDotPlot(seurat, group.by = "clusters",
+        c("score", "gene1")),
+    "ggplot")
+  
+  expect_type(
+    d_raw <- dittoDotPlot(seurat, getGenes(sce)[1:5], "clusters", data.out = TRUE, scale = FALSE,
+        slot = "counts"),
+    "list")
+  expect_type(
+    d_log <- dittoDotPlot(seurat, getGenes(sce)[1:5], "clusters", data.out = TRUE, scale = FALSE,
+        slot = "data"),
+    "list")
+  expect_true(all(
+    d_raw$data$color >= d_log$data$color))
+})
+
+test_that("Heatmap can be plotted for a Seurat and slot adjusted", {
+  expect_s3_class(
+    dittoHeatmap(
+        genes = getGenes(sce)[1:9],
+        object = seurat),
+    "pheatmap")
+  expect_s3_class(
+    dittoHeatmap(
+      genes = getGenes(sce)[1:9],
+      object = seurat,
+      slot = "counts"),
+    "pheatmap")
+  expect_true(all(
+    (dittoHeatmap(
+      genes = getGenes(sce)[1:9], object = seurat, data.out = TRUE)$mat) <=
+      (dittoHeatmap(
+        genes = getGenes(sce)[1:9], object = seurat, data.out = TRUE, slot = "counts")$mat)
+  ))
+})

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -1,111 +1,180 @@
 # Tests for functionality with Seurat objects
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-Seurat.R")
 
-# Convert SCE to Seurat
-seurat <- suppressWarnings(Seurat::as.Seurat(sce))
+sce$number <- as.numeric(seq_along(colnames(sce)))
+
+# Convert
+seurat <- try(Seurat::as.Seurat(sce), silent = FALSE)
+seurat_conversion_worked <- exists("seurat")
+
+# Ensure metadata has row.names (a past issue with the fxn)
 rownames(seurat@meta.data) <- colnames(seurat)
-
-# For importDemux
-sce.noDash <- sce
-colnames(sce.noDash) <- sapply(colnames(sce.noDash), function(X) strsplit(X, "-")[[1]][1])
-
-seurat.noDash <- suppressWarnings(Seurat::as.Seurat(sce.noDash))
-
-sce.demux <- importDemux(
-  sce.noDash, lane.meta = "groups",
-  demuxlet.best = "mock_demux.best",
-  verbose = FALSE)
-seurat.demux <- suppressWarnings(Seurat::as.Seurat(sce.demux))
-
-best <- read.table(file = "mock_demux.best", header=TRUE, sep="\t", stringsAsFactors = FALSE)
-samples <- vapply(
-  as.character(best$BEST),
-  function(X) strsplit(X,'-')[[1]][2],
-  FUN.VALUE = character(1))[seq_len(ncol(sce))]
-names(samples) <- NULL
 
 ### TESTS
 test_that("dittoBarPlot works for a Seurat", {
-  expect_s3_class(
-    dittoBarPlot(
-      seurat, "clusters", group.by = "age"),
-    "ggplot")
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+    expect_s3_class(
+        dittoBarPlot(
+            seurat, "clusters", group.by = "age"),
+        "ggplot")
 })
 
-test_that("importDemux works for a Seurat", {
-  expect_s4_class(
-    t <- importDemux(
-      object = seurat.noDash, lane.meta = "groups",
-      demuxlet.best = "mock_demux.best"),
-    "Seurat")
-  # All called samples are correct
-  expect_true(all(samples == meta("Sample", t)))
-})
-
-test_that("demux.SNP.summary & demux.calls.summary work for a Seurat", {
-  expect_s3_class(
-    demux.SNP.summary(seurat.demux),
-    "ggplot")
-  expect_s3_class(
-    demux.calls.summary(seurat.demux),
-    "ggplot")
+test_that("importDemux + demux.SNP.summary & demux.calls.summary work for a Seurat", {
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+    ### Prep
+    sce.noDash <- sce
+    colnames(sce.noDash) <- sapply(colnames(sce.noDash), function(X) strsplit(X, "-")[[1]][1])
+    # Convert that SCE to Seurat
+    seurat.noDash <- try(Seurat::as.Seurat(sce.noDash), silent = TRUE)
+    
+    expect_s4_class(
+        seurat.demux <- importDemux(
+            object = seurat.noDash, lane.meta = "groups",
+            demuxlet.best = "mock_demux.best"),
+        "Seurat")
+    
+    ### All called samples are correct
+    # What they should be
+    best <- read.table(file = "mock_demux.best", header=TRUE, sep="\t", stringsAsFactors = FALSE)
+    samples <- vapply(
+        as.character(best$BEST),
+        function(X) strsplit(X,'-')[[1]][2],
+        FUN.VALUE = character(1))[seq_len(ncol(sce))]
+    names(samples) <- NULL
+    # Check
+    expect_true(all(samples == meta("Sample", seurat.demux)))
+    
+    ### Vizs
+    expect_s3_class(
+        demux.SNP.summary(seurat.demux),
+        "ggplot")
+    expect_s3_class(
+        demux.calls.summary(seurat.demux),
+        "ggplot")
 })
   
 test_that("dittoDimPlot work for a Seurat & 'slot' input usable", {
   expect_s3_class(
-    dittoDimPlot(
-      "groups", object=seurat),
-    "ggplot")
+      dittoDimPlot(
+          "groups", object=seurat),
+      "ggplot")
   
   df <- dittoDimPlot("gene1", object = seurat, data.out = TRUE,
       slot = "counts")
   expect_equal(
-    df$Target_data$color,
-    round(df$Target_data$color,0))
+      df$Target_data$color,
+      round(df$Target_data$color,0))
 })
 
 test_that("dittoDotPlot works with gene and meta data for a Seurat, with 'slot' doing what it should", {
-  expect_s3_class(
-    print(dittoDotPlot(seurat, group.by = "clusters",
-        getGenes(sce)[1:5])),
-    "ggplot")
-  expect_s3_class(
-    dittoDotPlot(seurat, group.by = "clusters",
-        c("score", "score2", "score3")),
-    "ggplot")
-  expect_s3_class(
-    dittoDotPlot(seurat, group.by = "clusters",
-        c("score", "gene1")),
-    "ggplot")
-  
-  expect_type(
-    d_raw <- dittoDotPlot(seurat, getGenes(sce)[1:5], "clusters", data.out = TRUE, scale = FALSE,
-        slot = "counts"),
-    "list")
-  expect_type(
-    d_log <- dittoDotPlot(seurat, getGenes(sce)[1:5], "clusters", data.out = TRUE, scale = FALSE,
-        slot = "data"),
-    "list")
-  expect_true(all(
-    d_raw$data$color >= d_log$data$color))
+    expect_s3_class(
+        print(dittoDotPlot(seurat, group.by = "clusters",
+            getGenes(sce)[1:5])),
+        "ggplot")
+    expect_s3_class(
+        dittoDotPlot(seurat, group.by = "clusters",
+            c("score", "score2", "score3")),
+        "ggplot")
+    expect_s3_class(
+        dittoDotPlot(seurat, group.by = "clusters",
+            c("score", "gene1")),
+        "ggplot")
+    
+    expect_type(
+        d_raw <- dittoDotPlot(seurat, getGenes(sce)[1:5], "clusters", data.out = TRUE, scale = FALSE,
+            slot = "counts"),
+        "list")
+    expect_type(
+        d_log <- dittoDotPlot(seurat, getGenes(sce)[1:5], "clusters", data.out = TRUE, scale = FALSE,
+            slot = "data"),
+        "list")
+    expect_true(all(
+        d_raw$data$color >= d_log$data$color))
 })
 
 test_that("Heatmap can be plotted for a Seurat and slot adjusted", {
-  expect_s3_class(
-    dittoHeatmap(
-        genes = getGenes(sce)[1:9],
-        object = seurat),
-    "pheatmap")
-  expect_s3_class(
-    dittoHeatmap(
-      genes = getGenes(sce)[1:9],
-      object = seurat,
-      slot = "counts"),
-    "pheatmap")
-  expect_true(all(
-    (dittoHeatmap(
-      genes = getGenes(sce)[1:9], object = seurat, data.out = TRUE)$mat) <=
-      (dittoHeatmap(
-        genes = getGenes(sce)[1:9], object = seurat, data.out = TRUE, slot = "counts")$mat)
-  ))
+    expect_s3_class(
+        dittoHeatmap(
+            genes = getGenes(sce)[1:9],
+            object = seurat),
+        "pheatmap")
+    expect_s3_class(
+        dittoHeatmap(
+            genes = getGenes(sce)[1:9],
+            object = seurat,
+            slot = "counts"),
+        "pheatmap")
+    expect_true(all(
+        (dittoHeatmap(
+            genes = getGenes(sce)[1:9], object = seurat, data.out = TRUE)$mat) <=
+            (dittoHeatmap(
+                genes = getGenes(sce)[1:9], object = seurat, data.out = TRUE, slot = "counts")$mat)
+    ))
 })
+
+test_that("DimHex & ScatterHex work for Seurat", {
+    expect_s3_class(dittoDimHex(object=seurat), "ggplot")
+    expect_s3_class(dittoDimHex("number", object=seurat), "ggplot")
+    # Slot / Assay
+    expect_s3_class((p1 <- dittoDimHex(object=seurat, "gene1", data.out = TRUE))[[1]], "ggplot")
+    expect_s3_class((p2 <- dittoDimHex("gene1", object=seurat, slot = "counts", data.out = TRUE))$plot, "ggplot")
+    expect_s3_class((p3 <- dittoDimHex("gene1", object=sce, assay = "counts", data.out = TRUE))$plot, "ggplot")
+    expect_false(identical(p1$data$color, p2$data$color))
+    expect_true(identical(p2$data$color, p3$data$color))
+    # Scatter - Slot / Assay Adjustment
+    expect_s3_class((p <- dittoScatterHex("gene1", "gene1", "gene1", object = seurat, data.out = TRUE,
+        slot.x = "counts",
+        slot.y = "counts",
+        adjustment.color = "z-score"))$plot, "ggplot")
+    expect_equal(
+        p$data$X,
+        round(p$data$Y,0))
+    expect_equal(
+        mean(p$data$color),
+        0)
+})
+
+test_that("VaryCells works for a Seurat", {
+    expect_s3_class(
+        multi_dittoDimPlotVaryCells("gene1", object=seurat, "age"),
+        "gtable")
+})
+
+test_that("dittoPlot can work for a Seurat", {
+    expect_s3_class(
+        dittoPlot(
+            "gene1", object=seurat, group.by = "clusters",
+            plots = c("vlnplot", "boxplot", "jitter")),
+        "ggplot")
+})
+
+test_that("dittoPlotVarsAcrossGroups can work for a Seurat", {
+    sce$half <- c(rep("a", 40), rep("b", ncells-40))
+    sce$quarter <- sce$half
+    sce$quarter[21:40] <- "c"
+    sce$quarter[51:ncells] <- "d"
+    expect_s3_class(
+        dittoPlotVarsAcrossGroups(
+            getGenes(sce)[1:5], object=sce, group.by = "quarter"),
+        "ggplot")
+})
+
+test_that("dittoScatterPlot can plot genes or metadata for a Seurat, with'slot' adjustable", {
+    expect_s3_class(
+        dittoScatterPlot(
+            "gene1", "number", object = seurat),
+        "ggplot")
+    expect_s3_class(
+        dittoScatterPlot(
+            "gene1", "gene1", object = seurat),
+        "ggplot")
+    
+    df <- dittoScatterPlot("gene1", "gene1", "gene1", NULL, object = seurat,
+        slot.x = "counts",
+        slot.y = "counts",
+        data.out = TRUE)
+    expect_equal(
+        df$Target_data$X,
+        round(df$Target_data$Y,0))
+})
+    

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -4,11 +4,13 @@
 sce$number <- as.numeric(seq_along(colnames(sce)))
 
 # Convert
-seurat <- try(Seurat::as.Seurat(sce), silent = FALSE)
+try(seurat <- Seurat::as.Seurat(sce), silent = TRUE)
 seurat_conversion_worked <- exists("seurat")
 
 # Ensure metadata has row.names (a past issue with the fxn)
-rownames(seurat@meta.data) <- colnames(seurat)
+if (seurat_conversion_worked) {
+    rownames(seurat@meta.data) <- colnames(seurat)
+}
 
 ### TESTS
 test_that("dittoBarPlot works for a Seurat", {
@@ -172,13 +174,13 @@ test_that("dittoPlotVarsAcrossGroups can work for a Seurat", {
     
     skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
 
-    sce$half <- c(rep("a", 40), rep("b", ncells-40))
-    sce$quarter <- sce$half
-    sce$quarter[21:40] <- "c"
-    sce$quarter[51:ncells] <- "d"
+    seurat$half <- c(rep("a", 40), rep("b", ncells-40))
+    seurat$quarter <- seurat$half
+    seurat$quarter[21:40] <- "c"
+    seurat$quarter[51:ncells] <- "d"
     expect_s3_class(
         dittoPlotVarsAcrossGroups(
-            getGenes(sce)[1:5], object=sce, group.by = "quarter"),
+            getGenes(seurat)[1:5], object=seurat, group.by = "quarter"),
         "ggplot")
 })
 

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -20,7 +20,9 @@ test_that("dittoBarPlot works for a Seurat", {
 })
 
 test_that("importDemux + demux.SNP.summary & demux.calls.summary work for a Seurat", {
+    
     skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+
     ### Prep
     sce.noDash <- sce
     colnames(sce.noDash) <- sapply(colnames(sce.noDash), function(X) strsplit(X, "-")[[1]][1])
@@ -54,19 +56,25 @@ test_that("importDemux + demux.SNP.summary & demux.calls.summary work for a Seur
 })
   
 test_that("dittoDimPlot work for a Seurat & 'slot' input usable", {
-  expect_s3_class(
-      dittoDimPlot(
-          "groups", object=seurat),
-      "ggplot")
-  
-  df <- dittoDimPlot("gene1", object = seurat, data.out = TRUE,
-      slot = "counts")
-  expect_equal(
-      df$Target_data$color,
-      round(df$Target_data$color,0))
+    
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+
+    expect_s3_class(
+        dittoDimPlot(
+            "groups", object=seurat),
+        "ggplot")
+    
+    df <- dittoDimPlot("gene1", object = seurat, data.out = TRUE,
+        slot = "counts")
+    expect_equal(
+        df$Target_data$color,
+        round(df$Target_data$color,0))
 })
 
 test_that("dittoDotPlot works with gene and meta data for a Seurat, with 'slot' doing what it should", {
+    
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+  
     expect_s3_class(
         print(dittoDotPlot(seurat, group.by = "clusters",
             getGenes(sce)[1:5])),
@@ -93,6 +101,9 @@ test_that("dittoDotPlot works with gene and meta data for a Seurat, with 'slot' 
 })
 
 test_that("Heatmap can be plotted for a Seurat and slot adjusted", {
+    
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+
     expect_s3_class(
         dittoHeatmap(
             genes = getGenes(sce)[1:9],
@@ -113,6 +124,9 @@ test_that("Heatmap can be plotted for a Seurat and slot adjusted", {
 })
 
 test_that("DimHex & ScatterHex work for Seurat", {
+    
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+
     expect_s3_class(dittoDimHex(object=seurat), "ggplot")
     expect_s3_class(dittoDimHex("number", object=seurat), "ggplot")
     # Slot / Assay
@@ -135,12 +149,18 @@ test_that("DimHex & ScatterHex work for Seurat", {
 })
 
 test_that("VaryCells works for a Seurat", {
+    
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+
     expect_s3_class(
         multi_dittoDimPlotVaryCells("gene1", object=seurat, "age"),
         "gtable")
 })
 
 test_that("dittoPlot can work for a Seurat", {
+    
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+
     expect_s3_class(
         dittoPlot(
             "gene1", object=seurat, group.by = "clusters",
@@ -149,6 +169,9 @@ test_that("dittoPlot can work for a Seurat", {
 })
 
 test_that("dittoPlotVarsAcrossGroups can work for a Seurat", {
+    
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+
     sce$half <- c(rep("a", 40), rep("b", ncells-40))
     sce$quarter <- sce$half
     sce$quarter[21:40] <- "c"
@@ -160,6 +183,9 @@ test_that("dittoPlotVarsAcrossGroups can work for a Seurat", {
 })
 
 test_that("dittoScatterPlot can plot genes or metadata for a Seurat, with'slot' adjustable", {
+    
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
+
     expect_s3_class(
         dittoScatterPlot(
             "gene1", "number", object = seurat),

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -3,13 +3,16 @@
 
 sce$number <- as.numeric(seq_along(colnames(sce)))
 
-seurat <- suppressWarnings(Seurat::as.Seurat(sce))
+# Convert
+seurat <- try(Seurat::as.Seurat(sce), silent = FALSE)
+seurat_conversion_worked <- exists("seurat")
 
-# Ensure metadata has row.names (past issue with the fxn)
+# Ensure metadata has row.names (a past issue with the fxn)
 rownames(seurat@meta.data) <- colnames(seurat)
 
 ### TESTS
 test_that("dittoBarPlot works for a Seurat", {
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
     expect_s3_class(
         dittoBarPlot(
             seurat, "clusters", group.by = "age"),
@@ -17,11 +20,12 @@ test_that("dittoBarPlot works for a Seurat", {
 })
 
 test_that("importDemux + demux.SNP.summary & demux.calls.summary work for a Seurat", {
+    skip_if_not(seurat_conversion_worked, message = "Seurat conversion bug")
     ### Prep
     sce.noDash <- sce
     colnames(sce.noDash) <- sapply(colnames(sce.noDash), function(X) strsplit(X, "-")[[1]][1])
     # Convert that SCE to Seurat
-    seurat.noDash <- suppressWarnings(Seurat::as.Seurat(sce.noDash))
+    seurat.noDash <- try(Seurat::as.Seurat(sce.noDash), silent = TRUE)
     
     expect_s4_class(
         seurat.demux <- importDemux(

--- a/tests/testthat/test-data-output.R
+++ b/tests/testthat/test-data-output.R
@@ -3,49 +3,59 @@
 
 test_that("Data outputing works for ScatterPlot", {
     expect_type(
-        data <- dittoScatterPlot("gene1", "gene2", object = seurat, data.out = TRUE),
+        data <- dittoScatterPlot("gene1", "gene2", object = sce, data.out = TRUE),
         "list")
     expect_true(is.data.frame(data$Target_data))
     expect_true(is.data.frame(data$Others_data))
-    expect_true(ncol(data$Target_data) >= 2 && nrow(data$Target_data) == ncol(seurat))
+    expect_true(ncol(data$Target_data) >= 2 && nrow(data$Target_data) == ncol(sce))
 })
 
 test_that("Data outputing works for DimPlot", {
     expect_type(
-        data <- dittoDimPlot("gene1", object = seurat, data.out = TRUE),
+        data <- dittoDimPlot("gene1", object = sce, data.out = TRUE),
         "list")
     expect_true(is.data.frame(data$Target_data))
     expect_true(is.data.frame(data$Others_data))
-    expect_true(ncol(data$Target_data) > 2 && nrow(data$Target_data) == ncol(seurat))
+    expect_true(ncol(data$Target_data) > 2 && nrow(data$Target_data) == ncol(sce))
 })
 
 test_that("Data outputing works for BarPlot", {
     expect_type(
-        data <- dittoBarPlot("clusters", object = seurat, group.by = "age", data.out = TRUE),
+        data <- dittoBarPlot("clusters", object = sce, group.by = "age", data.out = TRUE),
         "list")
     expect_true(is.data.frame(data$data))
 })
 
 test_that("Data outputing works for Plot", {
     expect_type(
-        data <- dittoPlot("gene1", object = seurat, group.by = "age", color.by = "age", data.out = TRUE),
+        data <- dittoPlot("gene1", object = sce, group.by = "age", color.by = "age", data.out = TRUE),
         "list")
     expect_true(is.data.frame(data$data))
-    expect_true(ncol(data$data) > 2 && nrow(data$data) == ncol(seurat))
+    expect_true(ncol(data$data) > 2 && nrow(data$data) == ncol(sce))
 })
 
 test_that("Data outputing works for Plot_VarsByGroup", {
     expect_type(
-        data <- dittoPlotVarsAcrossGroups(c("gene1", "gene2"), object = seurat, group.by = "age", data.out = TRUE),
+        data <- dittoPlotVarsAcrossGroups(c("gene1", "gene2"), object = sce, group.by = "age", data.out = TRUE),
         "list")
     expect_true(is.data.frame(data$data))
 })
 
 test_that("Data outputing works for Heatmap", {
     expect_type(
-        hm <- dittoHeatmap(c("gene1", "gene2"), object = seurat,
+        hm <- dittoHeatmap(c("gene1", "gene2"), object = sce,
             data.out = TRUE),
         "list")
     expect_true("mat" %in% names(hm))
 })
 
+test_that("dittoDotPlot data.out works", {
+    # scaling on by default
+    expect_type(
+        d <- dittoDotPlot(sce, getGenes(sce)[1:5], "clusters",
+            data.out = TRUE),
+        "list")
+    expect_equal(names(d), c("p", "data"))
+    expect_s3_class(d$p, "ggplot")
+    expect_s3_class(d$data, "data.frame")
+})

--- a/tests/testthat/test-dataImport.R
+++ b/tests/testthat/test-dataImport.R
@@ -1,4 +1,4 @@
-# Tests for importDemux2Seurat function
+# Tests for importDittoBulk function
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-dataImport.R")
 
 library(DESeq2)

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -10,18 +10,18 @@ meta2 <- "clusters"
 test_that("Showing hover.data works for ScatterPlot (with cells.use)", {
     if (requireNamespace("plotly", quietly = TRUE)) {
         expect_s3_class(
-            dittoScatterPlot(gene1, gene2, object = seurat, do.hover = TRUE,
+            dittoScatterPlot(gene1, gene2, object = sce, do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident"),
                 data.out = TRUE)[[1]],
             "plotly")
         expect_s3_class(
-            dittoScatterPlot(gene1, gene2, object = seurat, do.hover = TRUE,
+            dittoScatterPlot(gene1, gene2, object = sce, do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident"),
-                cells.use = rep(c(TRUE,FALSE), length.out = ncol(seurat))),
+                cells.use = rep(c(TRUE,FALSE), length.out = ncol(sce))),
             "plotly")
     } else {
         expect_warning(
-            dittoScatterPlot(gene1, gene2, object = seurat, do.hover = TRUE,
+            dittoScatterPlot(gene1, gene2, object = sce, do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident")),
             "plotly installation required for using hover", fixed = TRUE)
     }
@@ -30,18 +30,18 @@ test_that("Showing hover.data works for ScatterPlot (with cells.use)", {
 test_that("Showing hover.data works for DimPlot (with cells.use)", {
     if (requireNamespace("plotly", quietly = TRUE)) {
         expect_s3_class(
-            dittoDimPlot(gene1, object = seurat, do.hover = TRUE,
+            dittoDimPlot(gene1, object = sce, do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident"),
                 data.out = TRUE)[[1]],
             "plotly")
         expect_s3_class(
-            dittoDimPlot(gene1, object = seurat, do.hover = TRUE,
+            dittoDimPlot(gene1, object = sce, do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident"),
-                cells.use = rep(c(TRUE,FALSE), length.out = ncol(seurat))),
+                cells.use = rep(c(TRUE,FALSE), length.out = ncol(sce))),
             "plotly")
     } else {
         expect_warning(
-            dittoDimPlot(gene1, object = seurat, do.hover = TRUE,
+            dittoDimPlot(gene1, object = sce, do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident")),
             "plotly installation required for using hover", fixed = TRUE)
     }
@@ -51,22 +51,22 @@ test_that("Showing hover.data works for BarPlot (with cells.use)", {
     if (requireNamespace("plotly", quietly = TRUE)) {
         expect_s3_class(
             dittoBarPlot(
-                meta1, object = seurat,
+                meta1, object = sce,
                 group.by = meta2,
                 do.hover = TRUE,
                 data.out = TRUE)[[1]],
             "plotly")
         expect_s3_class(
             dittoBarPlot(
-                meta1, object = seurat,
+                meta1, object = sce,
                 group.by = meta2,
                 do.hover = TRUE,
-                cells.use = rep(c(TRUE,FALSE), length.out = ncol(seurat))),
+                cells.use = rep(c(TRUE,FALSE), length.out = ncol(sce))),
             "plotly")
     } else {
         expect_warning(
             dittoBarPlot(
-                meta1, object = seurat,
+                meta1, object = sce,
                 group.by = meta2,
                 do.hover = TRUE),
             "plotly installation required for using hover", fixed = TRUE)
@@ -77,7 +77,7 @@ test_that("Showing hover.data works for Plot (with cells.use)", {
     if (requireNamespace("plotly", quietly = TRUE)) {
         expect_s3_class(
             dittoPlot(
-                gene1, object = seurat,
+                gene1, object = sce,
                 group.by = meta2, color.by = meta2,
                 do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident"),
@@ -85,16 +85,16 @@ test_that("Showing hover.data works for Plot (with cells.use)", {
             "plotly")
         expect_s3_class(
             dittoBoxPlot(
-                gene1, object = seurat,
+                gene1, object = sce,
                 group.by = meta2, color.by = meta2,
                 do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident"),
-                cells.use = rep(c(TRUE,FALSE), length.out = ncol(seurat))),
+                cells.use = rep(c(TRUE,FALSE), length.out = ncol(sce))),
             "plotly")
     } else {
         expect_warning(
             dittoPlot(
-                gene1, object = seurat,
+                gene1, object = sce,
                 group.by = meta2, color.by = meta2,
                 do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident")),
@@ -106,7 +106,7 @@ test_that("Expected hover.data warning for dittoRidgePlot (if plotly available)"
     if (requireNamespace("plotly", quietly = TRUE)) {
         expect_warning(
             dittoRidgePlot(
-                gene1, object = seurat, plots = c("ridgeplot", "jitter"),
+                gene1, object = sce, plots = c("ridgeplot", "jitter"),
                 group.by = meta2, color.by = meta2,
                 do.hover = TRUE,
                 hover.data = c(gene1,meta1,"ident"),
@@ -119,21 +119,23 @@ test_that("Showing hover.data works for VarsAcrossGroups (with cells.use)", {
     if (requireNamespace("plotly", quietly = TRUE)) {
         expect_s3_class(
             dittoPlotVarsAcrossGroups(c(gene1, gene2, gene3),
-                object = seurat, group.by = meta2,
+                object = sce, group.by = meta2,
                 do.hover = TRUE,
                 data.out = TRUE)[[1]],
             "plotly")
         expect_s3_class(
             dittoPlotVarsAcrossGroups(c(gene1, gene2, gene3),
-                object = seurat, group.by = meta2,
+                object = sce, group.by = meta2,
                 do.hover = TRUE,
-                cells.use = rep(c(TRUE,FALSE), length.out = ncol(seurat))),
+                cells.use = rep(c(TRUE,FALSE), length.out = ncol(sce))),
             "plotly")
     } else {
         expect_warning(
             dittoPlotVarsAcrossGroups(c(gene1, gene2, gene3),
-                object = seurat, group.by = meta2,
+                object = sce, group.by = meta2,
                 do.hover = TRUE),
             "plotly installation required for using hover", fixed = TRUE)
     }
 })
+
+## For Future: Could add checking of assay/slot/adjustments

--- a/tests/testthat/test-multi_VaryCells.R
+++ b/tests/testthat/test-multi_VaryCells.R
@@ -1,51 +1,45 @@
 # Tests for multi_dittoDimPlotVaryCells function
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-multi_VaryCells.R")
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
+sce$number <- as.numeric(seq_along(colnames(sce)))
 grp <- "age"
 cont <- "gene2"
 disc <- "groups"
 
 test_that("VaryCells fxn can show continuous or discrete data", {
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp),
-        "gtable")
-    expect_s3_class(
-        multi_dittoDimPlotVaryCells(disc, object=seurat, grp),
-        "gtable")
-})
-
-test_that("VaryCells works for SCE", {
-    expect_s3_class(
         multi_dittoDimPlotVaryCells(cont, object=sce, grp),
+        "gtable")
+    expect_s3_class(
+        multi_dittoDimPlotVaryCells(disc, object=sce, grp),
         "gtable")
 })
 
 test_that("VaryCells fxn can output plots as a list", {
     expect_type(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp,
             list.out = TRUE),
         "list")
 })
 
 test_that("VaryCells fxn can adjust how expression data is obtained", {
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp,
             min = 0, max =2000),
         "gtable")
     #Manual Check: scales should be different in the next 2
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp,
             slot = "counts"),
         "gtable")
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp),
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp),
         "gtable")
 })
 
 test_that("VaryCells fxn levels subsetting works", {
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp,
             vary.cells.levels = 1:2),
         "gtable")
 })
@@ -53,27 +47,27 @@ test_that("VaryCells fxn levels subsetting works", {
 test_that("VaryCells 'show.' tweaks all work", {
     # Manual Check: Removes allcells & legend & titles
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp,
             show.allcells.plot = FALSE, show.legend.single = FALSE,
             show.titles = FALSE),
         "gtable")
     # Manual Check: Adds legends to all plots
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp,
             show.legend.allcells.plot = TRUE, show.legend.plots = TRUE),
         "gtable")
 })
 
 test_that("VaryCells allcells title can be changed", {
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp,
             allcells.main = "DIFFERENT"),
         "gtable")
 })
 
 test_that("VaryCells color.panel can be adjusted", {
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(disc, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(disc, object=sce, grp,
             color.panel = c("red","blue","yellow","gray50","purple"),
             colors = 5:1),
         "gtable")
@@ -81,7 +75,7 @@ test_that("VaryCells color.panel can be adjusted", {
 
 test_that("VaryCells color.panel can be adjusted", {
     expect_s3_class(
-        multi_dittoDimPlotVaryCells(disc, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(disc, object=sce, grp,
             color.panel = c("red","blue","yellow","gray50","purple"),
             colors = 5:1),
         "gtable")
@@ -89,14 +83,14 @@ test_that("VaryCells color.panel can be adjusted", {
 
 test_that("VaryCells fxn errors as wanted when given 'cells.use'.", {
     expect_error(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp,
-            cells.use = colnames(seurat)[1:5]),
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp,
+            cells.use = colnames(sce)[1:5]),
         "Further subsetting with 'cells.use'", fixed = TRUE)
 })
 
 test_that("VaryCells tells that 'main' is ignored.", {
     expect_message(
-        multi_dittoDimPlotVaryCells(cont, object=seurat, grp,
+        multi_dittoDimPlotVaryCells(cont, object=sce, grp,
             main = "HELLO"),
         "'main' ignored", fixed = TRUE)
 })

--- a/tests/testthat/test-multis.R
+++ b/tests/testthat/test-multis.R
@@ -1,7 +1,7 @@
 # Tests for multi_dittoDimPlot & multi_dittoPlot functions
 # library(dittoSeq); library(testthat); source("setup.R"); source("test-multis.R")
 
-seurat$number <- as.numeric(seq_along(colnames(seurat)))
+sce$number <- as.numeric(seq_along(colnames(sce)))
 cont <- "gene1"
 cont2 <- "gene2"
 cont3 <- "gene3"
@@ -13,77 +13,77 @@ discs_3 <- c(disc, disc2, disc3)
 
 test_that("multi Plot&DimPlot work for multiple (3) vars", {
     expect_s3_class(
-        multi_dittoDimPlot(object=seurat, vars = conts_3),
+        multi_dittoDimPlot(object=sce, vars = conts_3),
         "gtable")
     expect_s3_class(
-        multi_dittoDimPlot(object=seurat, vars = discs_3),
+        multi_dittoDimPlot(object=sce, vars = discs_3),
         "gtable")
     
     expect_s3_class(
-        multi_dittoPlot(object=seurat, vars = conts_3, group.by = disc),
+        multi_dittoPlot(object=sce, vars = conts_3, group.by = disc),
         "gtable")
 })
 
 test_that("multi Plot&DimPlot work for single (1) vars", {
     expect_s3_class(
-        multi_dittoDimPlot(object=seurat, vars = cont),
+        multi_dittoDimPlot(object=sce, vars = cont),
         "gtable")
     expect_s3_class(
-        multi_dittoDimPlot(object=seurat, vars = disc),
+        multi_dittoDimPlot(object=sce, vars = disc),
         "gtable")
     
     expect_s3_class(
-        multi_dittoPlot(object=seurat, vars = cont, group.by = disc),
+        multi_dittoPlot(object=sce, vars = cont, group.by = disc),
         "gtable")
 })
 
 test_that("multi Plot&DimPlot give reasonable error for no (0) vars", {
     expect_error(
-        multi_dittoDimPlot(object=seurat, vars = NULL),
+        multi_dittoDimPlot(object=sce, vars = NULL),
         "No 'vars' provided.", fixed = TRUE)
     
     expect_error(
-        multi_dittoPlot(object=seurat, vars = NULL, group.by = disc),
+        multi_dittoPlot(object=sce, vars = NULL, group.by = disc),
         "No 'vars' provided.", fixed = TRUE)
 })
 
 test_that("multi Plot&DimPlot can output plots as a list", {
     expect_type(
-        multi_dittoDimPlot(object=seurat, conts_3,
+        multi_dittoDimPlot(object=sce, conts_3,
             list.out = TRUE),
         "list")
     
     expect_type(
-        multi_dittoPlot(object=seurat, conts_3, disc,
+        multi_dittoPlot(object=sce, conts_3, disc,
             list.out = TRUE),
         "list")
 })
 
 test_that("multi Plot&DimPlot messaage & output plots as a list when data.out or do.hover given", {
     expect_type(
-        multi_dittoDimPlot(object=seurat, conts_3,
+        multi_dittoDimPlot(object=sce, conts_3,
             data.out = TRUE),
         "list")
     expect_type(
-        multi_dittoDimPlot(object=seurat, conts_3,
+        multi_dittoDimPlot(object=sce, conts_3,
             do.hover = TRUE),
         "list")
     
     expect_type(
-        multi_dittoPlot(object=seurat, conts_3, disc,
+        multi_dittoPlot(object=sce, conts_3, disc,
             data.out = TRUE),
         "list")
     expect_type(
-        multi_dittoPlot(object=seurat, conts_3, disc,
+        multi_dittoPlot(object=sce, conts_3, disc,
             data.out = TRUE),
         "list")
     
     expect_message(
-        multi_dittoDimPlot(object=seurat, conts_3,
+        multi_dittoDimPlot(object=sce, conts_3,
             do.hover = TRUE),
         "outputting as a list", fixed = TRUE)
     expect_message(
-        multi_dittoPlot(object=seurat, conts_3, disc,
+        multi_dittoPlot(object=sce, conts_3, disc,
             data.out = TRUE),
         "outputting as a list", fixed = TRUE)
 })
@@ -91,11 +91,11 @@ test_that("multi Plot&DimPlot messaage & output plots as a list when data.out or
 test_that("multi_dittoDimPlot 'axes.labels.show' works", {
     # Manual Check: axes labels hidden in 1st, shown in 2nd.
     expect_s3_class(
-        multi_dittoDimPlot(object=seurat, vars = conts_3,
+        multi_dittoDimPlot(object=sce, vars = conts_3,
             axes.labels.show = FALSE),
         "gtable")
     expect_s3_class(
-        multi_dittoDimPlot(object=seurat, vars = conts_3,
+        multi_dittoDimPlot(object=sce, vars = conts_3,
             axes.labels.show = TRUE),
         "gtable")
 })
@@ -103,11 +103,11 @@ test_that("multi_dittoDimPlot 'axes.labels.show' works", {
 test_that('multi_dittoPlot, giving "var" adjusts main or ylab as stated', {
     # Manual Check: Main titles same in both, ylab has "expression" only in 1st
     expect_s3_class(
-        multi_dittoPlot(object=seurat, vars = conts_3, disc,
+        multi_dittoPlot(object=sce, vars = conts_3, disc,
             main = "make", ylab = "make"),
         "gtable")
     expect_s3_class(
-        multi_dittoPlot(object=seurat, vars = conts_3, disc,
+        multi_dittoPlot(object=sce, vars = conts_3, disc,
             main = "var", ylab = "var"),
         "gtable")
 })
@@ -115,11 +115,11 @@ test_that('multi_dittoPlot, giving "var" adjusts main or ylab as stated', {
 test_that("multi Plot&DimPlot ncol & nrow adjust dims", {
     # Manual Check: Should be 2x2
     expect_s3_class(
-        multi_dittoDimPlot(object=seurat, vars = conts_3,
+        multi_dittoDimPlot(object=sce, vars = conts_3,
             ncol = 2, nrow = 2),
         "gtable")
     expect_s3_class(
-        multi_dittoPlot(object=seurat, vars = conts_3, group.by = disc,
+        multi_dittoPlot(object=sce, vars = conts_3, group.by = disc,
             ncol = 2, nrow = 2),
         "gtable")
 })
@@ -127,7 +127,7 @@ test_that("multi Plot&DimPlot ncol & nrow adjust dims", {
 test_that("multi Plot&DimPlot work with additional single-plotter inputs", {
     # Manual Check: Should be 2x2
     expect_s3_class(
-        multi_dittoDimPlot(object=seurat, vars = conts_3,
+        multi_dittoDimPlot(object=sce, vars = conts_3,
             reduction.use = "PCA",
             size = 5,
             opacity = 0.3,
@@ -145,7 +145,7 @@ test_that("multi Plot&DimPlot work with additional single-plotter inputs", {
         "gtable")
     
     expect_s3_class(
-        multi_dittoPlot(object=seurat, vars = conts_3, group.by = disc,
+        multi_dittoPlot(object=sce, vars = conts_3, group.by = disc,
             color.by = disc2,
             shape.by = disc,
             split.by = disc2,
@@ -159,7 +159,7 @@ test_that("multi Plot&DimPlot work with additional single-plotter inputs", {
             plots = "jitter"),
         "gtable")
     expect_s3_class(
-        multi_dittoPlot(object=seurat, vars = conts_3, group.by = disc,
+        multi_dittoPlot(object=sce, vars = conts_3, group.by = disc,
             color.by = disc2,
             shape.by = disc,
             split.by = disc2,

--- a/vignettes/dittoSeq.Rmd
+++ b/vignettes/dittoSeq.Rmd
@@ -42,7 +42,7 @@ these formats:
 Single-Cell:
 
 - SingleCellExperiment
-- Seurat (versions 2 & 3)
+- Seurat (v2 onwards)
 
 Bulk:
 
@@ -139,27 +139,9 @@ sce$cluster <- clusterCells(sce, use.dimred='PCA',
 sce
 ```
 
-Now that we have a single-cell dataset loaded and analyzed, let's convert it to
-a Seurat, and add a few extra metadata, for example purposes.
-
-```{r}
-## Transform into a Seurat for examples, and percent.mito
-# First, just to better align with a coupld Seurat conventions...
-sce$nCount_RNA <- colSums(counts(sce))
-sce$nFeature_RNA <- colSums(counts(sce)>0)
-sce1 <- sce
-reducedDimNames(sce1) <- c("pca", "umap")
-
-library(Seurat)
-seurat <- as.Seurat(sce1)
-seurat$percent.mito <- PercentageFeatureSet(seurat, pattern = "^MT")
-Idents(seurat) <- "cluster"
-
-rm(sce1)
-seurat
-```
-
-All functions will work the same for either the Seurat or SCE version.
+Now that we have a single-cell dataset loaded and analyzed as an SCE, but note:
+**All functions will work the same for single-cell data stored as either**
+**Seurat or SCE.**
 
 # Getting started
 
@@ -170,8 +152,8 @@ special is needed. Just load in your data if it isn't already loaded, then go!
 
 ```{r}
 library(dittoSeq)
-dittoDimPlot(seurat, "donor")
-dittoPlot(seurat, "ENO1", group.by = "label")
+dittoDimPlot(sce, "donor")
+dittoPlot(sce, "ENO1", group.by = "label")
 dittoBarPlot(sce, "label", group.by = "donor")
 ```
 
@@ -305,32 +287,32 @@ dimensionality reduction options for plotting.
 
 ```{r}
 # Retrieve all metadata slot names
-getMetas(seurat)
+getMetas(sce)
 # Query for the presence of a metadata slot
-isMeta("nCount_RNA", seurat)
+isMeta("nCount_RNA", sce)
 # Retrieve metadata values:
-meta("label", seurat)[1:10]
+meta("label", sce)[1:10]
 # Retrieve unique values of a metadata
-metaLevels("label", seurat)
+metaLevels("label", sce)
 ```
 
 ## Genes/Features
 
 ```{r}
 # Retrieve all gene names
-getGenes(seurat)[1:10]
+getGenes(sce)[1:10]
 # Query for the presence of a gene(s)
-isGene("CD3E", seurat)
-isGene(c("CD3E","ENO1","INS","non-gene"), seurat, return.values = TRUE)
+isGene("CD3E", sce)
+isGene(c("CD3E","ENO1","INS","non-gene"), sce, return.values = TRUE)
 # Retrieve gene expression values:
-gene("ENO1", seurat)[1:10]
+gene("ENO1", sce)[1:10]
 ```
 
 ## Reductions
 
 ```{r}
 # Retrieve all dimensionality reductions
-getReductions(seurat)
+getReductions(sce)
 ```
 
 These are what can be provided to `reduction.use` for `dittoDimPlot()`.
@@ -369,7 +351,7 @@ of `dittoDimPlot()` being dimensionality reductions like tsne, pca, umap or
 similar.
 
 ```{r, results = "hold"}
-dittoDimPlot(seurat, "label", reduction.use = "pca")
+dittoDimPlot(sce, "label", reduction.use = "pca")
 dittoDimPlot(sce, "ENO1")
 ```
 
@@ -379,7 +361,7 @@ dittoScatterPlot(
     x.var = "PPY", y.var = "INS",
     color.var = "label")
 dittoScatterPlot(
-    object = seurat,
+    object = sce,
     x.var = "nCount_RNA", y.var = "nFeature_RNA",
     color.var = "percent.mito")
 ```
@@ -404,7 +386,7 @@ the XXXX part that comes after `add.XXXX` or `do.XXXX`, as exemplified below.
 A few examples:
 
 ```{r}
-dittoDimPlot(seurat, "ident",
+dittoDimPlot(sce, "cluster",
              
              do.label = TRUE,
              labels.repel = FALSE,
@@ -431,8 +413,8 @@ summaries of cells/samples within each of those bins.
 The minimal functions will summarize density of cells/samples only using color.
 
 ```{r, results = "hold"}
-dittoDimHex(seurat)
-dittoScatterHex(seurat,
+dittoDimHex(sce)
+dittoScatterHex(sce,
     x.var = "PPY", y.var = "INS")
 ```
 
@@ -446,9 +428,9 @@ color-blindness friendliness of dittoSeq's default colors is no longer
 guaranteed.
 
 ```{r, results = "hold"}
-dittoDimHex(seurat, "INS")
+dittoDimHex(sce, "INS")
 dittoScatterHex(
-    object = seurat,
+    object = sce,
     x.var = "PPY", y.var = "INS",
     color.var = "label",
     colors = c(1:4,7), max.density = 15)
@@ -501,10 +483,10 @@ the `plots` input from c("jitter", "vlnplot") to c("ridgeplot") or
 c("boxplot","jitter"), respectively.
 
 ```{r, results = "hold"}
-dittoPlot(seurat, "ENO1", group.by = "label",
+dittoPlot(sce, "ENO1", group.by = "label",
     plots = c("vlnplot", "jitter"))
 dittoRidgePlot(sce, "ENO1", group.by = "label")
-dittoBoxPlot(seurat, "ENO1", group.by = "label")
+dittoBoxPlot(sce, "ENO1", group.by = "label")
 ```
 
 ### Adjustments to data representations
@@ -514,7 +496,7 @@ inputs, all of which start with the representation types' name.  For
 example...
 
 ```{r}
-dittoPlot(seurat, "ENO1", group.by = "label",
+dittoPlot(sce, "ENO1", group.by = "label",
     plots = c("jitter", "vlnplot", "boxplot"), # <- order matters
     
     # change the color and size of jitter points
@@ -542,8 +524,8 @@ controlled by the `scale` input.
 
 ```{r, results = "hold"}
 # dittoBarPlot
-dittoBarPlot(seurat, "label", group.by = "donor")
-dittoBarPlot(seurat, "label", group.by = "donor",
+dittoBarPlot(sce, "label", group.by = "donor")
+dittoBarPlot(sce, "label", group.by = "donor",
     scale = "count")
 ```
 
@@ -578,9 +560,9 @@ genes <- c("SST", "REG1A", "PPY", "INS", "CELA3A", "PRSS2", "CTRB1",
     "SPINK1", "CELA3B", "CLPS", "OLFM4", "ACTG1", "FTL")
 
 # Annotating and ordering cells by some meaningful feature(s):
-dittoHeatmap(seurat, genes,
+dittoHeatmap(sce, genes,
     annot.by = c("label", "donor"))
-dittoHeatmap(seurat, genes,
+dittoHeatmap(sce, genes,
     annot.by = c("label", "donor"),
     order.by = "donor")
 ```
@@ -593,7 +575,7 @@ shown. (`show_colnames` default is TRUE for bulk, and FALSE for single-cell.)
 
 ```{r}
 # Add annotations
-dittoHeatmap(seurat, genes,
+dittoHeatmap(sce, genes,
     annot.by = c("label", "donor"),
     scaled.to.max = TRUE,
     show_colnames = FALSE,
@@ -610,7 +592,7 @@ when the heatmap would be too complex for editing software like Illustrator.
 
 ```{r}
 # Highlight certain genes
-dittoHeatmap(seurat, genes, annot.by = c("label", "donor"),
+dittoHeatmap(sce, genes, annot.by = c("label", "donor"),
     highlight.features = genes[1:3],
     complex = TRUE)
 ```
@@ -630,6 +612,7 @@ Some setup for these, let's roughly pick out the markers of delta cells in
 this data set
 
 ```{r}
+# seurat <- as.Seurat(sce)
 # Idents(seurat) <- "label"
 # delta.marker.table <- FindMarkers(seurat, ident.1 = "delta")
 # delta.genes <- rownames(delta.marker.table)[1:20]
@@ -655,8 +638,8 @@ a similar range of values for all `vars` displayed and to emphasize differences
 between groups.
 
 ```{r}
-dittoDotPlot(seurat, vars = delta.genes, group.by = "label")
-dittoDotPlot(seurat, vars = delta.genes, group.by = "label",
+dittoDotPlot(sce, vars = delta.genes, group.by = "label")
+dittoDotPlot(sce, vars = delta.genes, group.by = "label",
     scale = FALSE)
 ```
 
@@ -671,9 +654,9 @@ point instead represents a gene (or metadata). More specifically, the average
 expression, within each x-grouping, of a gene (or value of a metadata).
 
 ```{r}
-multi_dittoPlot(seurat, delta.genes[1:6], group.by = "label",
+multi_dittoPlot(sce, delta.genes[1:6], group.by = "label",
     vlnplot.lineweight = 0.2, jitter.size = 0.3)
-dittoPlotVarsAcrossGroups(seurat, delta.genes, group.by = "label",
+dittoPlotVarsAcrossGroups(sce, delta.genes, group.by = "label",
     main = "Delta-cell Markers")
 ```
 
@@ -695,8 +678,8 @@ showing an "AllCells" plot as well, or of outputting the individual plots for
 making manually customized plot arrangements when `data.out = TRUE`.
 
 ```{r, results = "hold"}
-multi_dittoDimPlot(seurat, delta.genes[1:6])
-multi_dittoDimPlotVaryCells(seurat, delta.genes[1],
+multi_dittoDimPlot(sce, delta.genes[1:6])
+multi_dittoDimPlotVaryCells(sce, delta.genes[1],
     vary.cells.meta = "label")
 ```
 
@@ -718,20 +701,20 @@ logical vector that states whether each cell / sample should be included.
 
 ```{r}
 # Original
-dittoBarPlot(seurat, "label", group.by = "donor", scale = "count")
+dittoBarPlot(sce, "label", group.by = "donor", scale = "count")
 
 # First 10 cells
-dittoBarPlot(seurat, "label", group.by = "donor", scale = "count",
+dittoBarPlot(sce, "label", group.by = "donor", scale = "count",
     # String method
-    cells.use = colnames(seurat)[1:10]
+    cells.use = colnames(sce)[1:10]
     # Index method, which would achieve the same effect
     # cells.use = 1:10
     )
 
 # Acinar cells only
-dittoBarPlot(seurat, "label", group.by = "donor", scale = "count",
+dittoBarPlot(sce, "label", group.by = "donor", scale = "count",
     # Logical method
-    cells.use = meta("label", seurat) == "acinar")
+    cells.use = meta("label", sce) == "acinar")
 ```
 
 ## Faceting with split.by
@@ -740,9 +723,9 @@ Most diitoSeq plot types can be faceted into separate plots for distinct groups
 of cells with the `split.by` input.
 
 ```{r}
-dittoPlot(seurat, "PPY", group.by = "donor", 
+dittoPlot(sce, "PPY", group.by = "donor", 
     split.by = "label")
-dittoDimPlot(seurat, "PPY",
+dittoDimPlot(sce, "PPY",
     split.by = c("donor", "label"))
 ```
 
@@ -751,7 +734,7 @@ input. `split.adjust` allows inputs to be passed through to the ggplot
 functions used for achieving the faceting.
 
 ```{r}
-dittoPlot(seurat, "PPY", group.by = "donor", 
+dittoPlot(sce, "PPY", group.by = "donor", 
     split.by = "label",
     split.adjust = list(scales = "free_y"), max = NA)
 ```
@@ -759,7 +742,7 @@ dittoPlot(seurat, "PPY", group.by = "donor",
 When splitting is by only one metadata, the shape of the facet grid can be controlled with `split.ncol` and `split.nrow`.
 
 ```{r, fig.height=7}
-dittoRidgePlot(seurat, "PPY", group.by = "donor", 
+dittoRidgePlot(sce, "PPY", group.by = "donor", 
     split.by = "label",
     split.ncol = 1)
 ```
@@ -770,7 +753,7 @@ Relevant inputs are generally `main`, `sub`, `xlab`, `ylab`, `x.labels`, and
 `legend.title`.
 
 ```{r}
-dittoBarPlot(seurat, "label", group.by = "donor",
+dittoBarPlot(sce, "label", group.by = "donor",
     main = "Encounters",
     sub = "By Type",
     xlab = NULL, # NULL = remove
@@ -792,20 +775,20 @@ easy when nearby clusters appear too similar in tSNE/umap plots!
 
 ```{r, results="hold"}
 # original - discrete
-dittoDimPlot(seurat, "label")
+dittoDimPlot(sce, "label")
 # swapped colors
-dittoDimPlot(seurat, "label",
+dittoDimPlot(sce, "label",
     colors = 5:1)
 # different colors
-dittoDimPlot(seurat, "label",
+dittoDimPlot(sce, "label",
     color.panel = c("red", "orange", "purple", "yellow", "skyblue"))
 ```
 
 ```{r, results="hold"}
 # original - expression
-dittoDimPlot(seurat, "INS")
+dittoDimPlot(sce, "INS")
 # different colors
-dittoDimPlot(seurat, "INS",
+dittoDimPlot(sce, "INS",
     max.color = "red", min.color = "gray90")
 ```
 
@@ -815,7 +798,7 @@ Simply add  `data.out = TRUE` to any of the individual plotters and a
 representation of the underlying data will be output.
 
 ```{r}
-dittoBarPlot(seurat, "label", group.by = "donor",
+dittoBarPlot(sce, "label", group.by = "donor",
     data.out = TRUE)
 ```
 
@@ -825,7 +808,7 @@ expression matrix is represented before plotting, or even to use a different
 heatmap creator from pheatmap altogether.
 
 ```{r}
-dittoHeatmap(seurat, c("SST","CPE","GPX3"), cells.use = colnames(seurat)[1:5],
+dittoHeatmap(sce, c("SST","CPE","GPX3"), cells.use = colnames(sce)[1:5],
     data.out = TRUE)
 ```
 
@@ -844,10 +827,10 @@ dittoPlotVarsAcrossGroups), the `hover.data` input is not used.
 
 ```{r, eval = FALSE}
 # These can be finicky to render in knitting, but still, example code:
-dittoDimPlot(seurat, "INS",
+dittoDimPlot(sce, "INS",
     do.hover = TRUE,
     hover.data = c("label", "donor", "ENO1", "ident", "nCount_RNA"))
-dittoBarPlot(seurat, "label", group.by = "donor",
+dittoBarPlot(sce, "label", group.by = "donor",
     do.hover = TRUE)
 ```
 
@@ -875,7 +858,7 @@ ComplexHeatmap, then rasterization should be turned on by default when needed,
 but it can also be turned on manually with `use_raster = TRUE`.
 
 ```{r}
-dittoHeatmap(seurat, genes, scaled.to.max = TRUE,
+dittoHeatmap(sce, genes, scaled.to.max = TRUE,
     complex = TRUE,
     use_raster = TRUE)
 ```

--- a/vignettes/dittoSeq.Rmd
+++ b/vignettes/dittoSeq.Rmd
@@ -94,7 +94,7 @@ if (!requireNamespace("BiocManager", quietly = TRUE))
 BiocManager::install("dittoSeq")
 ```
 
-# Ref: Seurat<=>dittoSeq
+# Quick-Reference: Seurat<=>dittoSeq
 
 As of May 25th, 2021, Seurat-v4.0.2 & dittoSeq v1.4.1
 
@@ -129,7 +129,7 @@ break people's already existing code. Instead, dittoSeq input names are
 guaranteed to remain consistent across versions, unless a change is required for
 useful feature additions.
 
-Seurat Viz Input(s) | dittoSeq Equivalents
+Seurat Viz Input(s) | dittoSeq Equivalent(s)
 --- | ---
 `object` | SAME
 `features` | `var` / `vars` (generally the 2nd input, so name not needed!) OR `genes` & `metas` for dittoHeatmap()
@@ -147,7 +147,7 @@ Seurat Viz Input(s) | dittoSeq Equivalents
 `interactive` | `do.hover` = via plotly conversion
 [Not in Seurat] | `data.out`, `do.raster`, `do.letter`, `do.ellipse`, `add.trajectory.lineages` and others!
 
-## Some simple preprocessing
+# Setup: Some simple preprocessing
 
 For examples, we will use a pancreatic
 @baron_single-cell_2016 is not normalized nor dimensionality reduced upon
@@ -197,7 +197,7 @@ sce$percent.mito <- colSums(counts(sce)[grep("^MT-", rownames(sce)),])/sce$nCoun
 sce
 ```
 
-Now that we have a single-cell dataset loaded and analyzed as an SCE, but note:
+Now we have a single-cell dataset loaded and analyzed as an SCE, but note:
 **All functions will work the same for single-cell data stored as either**
 **Seurat or SCE.**
 

--- a/vignettes/dittoSeq.Rmd
+++ b/vignettes/dittoSeq.Rmd
@@ -79,7 +79,7 @@ dittoSeq plots might look like to a colorblind individual.
 Code used here for dataset processing and normalization should not be seen as
 a suggestion of the proper methods for performing such steps. dittoSeq is a
 visualization tool, and my focus while developing this vignette has been simply
-creating values required for providing visualization examples.
+creating values required for providing "pretty-enough" visualization examples.
 
 # Installation
 
@@ -93,6 +93,60 @@ if (!requireNamespace("BiocManager", quietly = TRUE))
 # Install dittoSeq
 BiocManager::install("dittoSeq")
 ```
+
+# Ref: Seurat<=>dittoSeq
+
+As of May 25th, 2021, Seurat-v4.0.2 & dittoSeq v1.5.1
+
+Because often users will be familiar with Seurat already, so this may be 90% of
+what you may need!
+
+## Functions
+
+Seurat Viz Function(s) | dittoSeq Equivalent(s)
+--- | ---
+DimPlot/ (I)FeaturePlot / UMAPPlot / etc. | dittoDimPlot / multi_dittoDimPlot
+VlnPlot / RidgePlot | dittoPlot / multi_dittoPlot
+DotPlot | dittoDotPlot
+FeatureScatter / GenePlot | dittoScatterPlot
+DoHeatmap | dittoHeatmap*
+[No Seurat Equivalent] | dittoBarPlot / dittoFreqPlot
+[No Seurat Equivalent] | dittoDimHex / dittoScatterHex
+[No Seurat Equivalent] | dittoPlotVarsAcrossGroups
+SpatialDimPlot, SpatialFeaturePlot, etc. | dittoSpatial (coming soon!)
+
+*Not all dittoSeq features exist in Seurat counterparts, and occasionally the
+same is true in the reverse.
+
+## Inputs
+
+See reference below for the equivalent names of major inputs
+
+For input names Seurat has had some inconsistency compared to its past. dittoSeq
+actually drew some of its parameter names from previous Seurat-equivalents in
+order to ease cross-conversion, but alas... I will NOT break peoples' code
+just to follow another package's changes (and especially not just for the
+purpose of "We like this name better now."). Instead, dittoSeq input names are
+guaranteed to remain consistent across versions, unless a change is required for
+useful feature additions.
+
+Seurat Viz Input(s) | dittoSeq Equivalents
+--- | ---
+`object` | SAME
+`features` | `var` / `vars` (generally the 2nd input, so name not needed!) OR `genes` & `metas` for dittoHeatmap()
+`cells` (cell subsetting is not always available) | `cells.use` (consistently available)
+`reduction` & `dims` | `reduction.use` & `dim.1`, `dim.2`
+`pt.size` | `size` (or `jitter.size`)
+`group.by` | SAME
+`split.by` | SAME
+`shape.by` | SAME and also available in dittoPlot()
+`fill.by` | `color.by` (can be used to subset `group.by` further!)
+`assay` / `slot` | SAME
+`order` = logical | `order` but = "unordered" (default), "increasing", or "decreasing"
+`cols` | `color.panel` for discrete OR `min.color`, `max.color` for continuous
+`label` & `label.size` & `repel` | `do.label` & `labels.size` & `labels.repel`
+`interactive` | `do.hover` = via plotly conversion
+[Not in Seurat] | `data.out`, `do.raster`, `do.letter`, `do.ellipse`, `add.trajectory.lineages` and others!
 
 ## Some simple preprocessing
 

--- a/vignettes/dittoSeq.Rmd
+++ b/vignettes/dittoSeq.Rmd
@@ -4,7 +4,7 @@ author:
 - name: Daniel Bunis
   affiliation: Bakar Computational Health Sciences Institute, University of California San Francisco, San
   email: daniel.bunis@ucsf.edu
-date: "October 9th, 2020"
+date: "May 25th, 2021"
 output:
   BiocStyle::html_document:
     toc_float: true
@@ -188,6 +188,11 @@ sce <- runUMAP(sce, pca = 10)
 library(bluster)
 sce$cluster <- clusterCells(sce, use.dimred='PCA',
     BLUSPARAM=NNGraphParam(cluster.fun="louvain"))
+
+# Add some metadata common to Seurat objects
+sce$nCount_RNA <- colSums(counts(sce))
+sce$nFeature_RNA <- colSums(counts(sce)>0)
+sce$percent.mito <- colSums(counts(sce)[grep("^MT-", rownames(sce)),])/sce$nCount_RNA 
 
 sce
 ```
@@ -404,7 +409,7 @@ of `dittoDimPlot()` being dimensionality reductions like tsne, pca, umap or
 similar.
 
 ```{r, results = "hold"}
-dittoDimPlot(sce, "label", reduction.use = "pca")
+dittoDimPlot(sce, "label", reduction.use = "PCA")
 dittoDimPlot(sce, "ENO1")
 ```
 
@@ -450,7 +455,7 @@ dittoDimPlot(sce, "cluster",
                  c("8","7","1"),
                  c("5","11","6"),
                  c("10","0")),
-             trajectory.cluster.meta = "ident")
+             trajectory.cluster.meta = "cluster")
 ```
 
 ## dittoDimHex & dittoScatterHex
@@ -882,7 +887,7 @@ dittoPlotVarsAcrossGroups), the `hover.data` input is not used.
 # These can be finicky to render in knitting, but still, example code:
 dittoDimPlot(sce, "INS",
     do.hover = TRUE,
-    hover.data = c("label", "donor", "ENO1", "ident", "nCount_RNA"))
+    hover.data = c("label", "donor", "ENO1", "cluster", "nCount_RNA"))
 dittoBarPlot(sce, "label", group.by = "donor",
     do.hover = TRUE)
 ```

--- a/vignettes/dittoSeq.Rmd
+++ b/vignettes/dittoSeq.Rmd
@@ -96,7 +96,7 @@ BiocManager::install("dittoSeq")
 
 # Ref: Seurat<=>dittoSeq
 
-As of May 25th, 2021, Seurat-v4.0.2 & dittoSeq v1.5.1
+As of May 25th, 2021, Seurat-v4.0.2 & dittoSeq v1.4.1
 
 Because often users will be familiar with Seurat already, so this may be 90% of
 what you may need!

--- a/vignettes/dittoSeq.Rmd
+++ b/vignettes/dittoSeq.Rmd
@@ -122,11 +122,10 @@ same is true in the reverse.
 
 See reference below for the equivalent names of major inputs
 
-For input names Seurat has had some inconsistency compared to its past. dittoSeq
-actually drew some of its parameter names from previous Seurat-equivalents in
-order to ease cross-conversion, but alas... I will NOT break peoples' code
-just to follow another package's changes (and especially not just for the
-purpose of "We like this name better now."). Instead, dittoSeq input names are
+Seurat has had inconsistency in input names from version to version. dittoSeq
+drew some of its parameter names from previous Seurat-equivalents to ease
+cross-conversion, but continuing to blindly copy their parameter standards will
+break people's already existing code. Instead, dittoSeq input names are
 guaranteed to remain consistent across versions, unless a change is required for
 useful feature additions.
 


### PR DESCRIPTION
Seurat bugs keep popping up that cause errors for dittoSeq in the Bioconductor Build System, so I will be minimizing the reliance on Seurat of as much of dittoSeq's build & check materials as possible.
- [x] Vignette: removes all remaining Seurat functions, though compensates for the lack of direct Seurat object examples by adding a Seurat <=> dittoSeq reference section.
- [x] Unit-tests: moves most tests from focusing on the previous `seurat` object to the also generated `sce` object, then collects all Seurat tests in a single script to allow for conditional skipping if Seurat's `as.Seurat()` converter breaks again.
