### PR TITLE
Add `height` and `width` parameters for resizing interactive plots.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dittoSeq
 Type: Package
 Title: User Friendly Single-Cell and Bulk RNA Sequencing Visualization
-Version: 1.5.1
+Version: 1.5.2
 Authors@R: c(person("Daniel", "Bunis", email = "daniel.bunis@ucsf.edu", role=c("aut", "cre")),
     person("Jared", "Andrews", email = "jared.andrews07@gmail.com", role=c("aut", "ctb")))
 Description: A universal, user friendly, single-cell and bulk RNA sequencing

--- a/R/DittoDimPlot.R
+++ b/R/DittoDimPlot.R
@@ -114,6 +114,8 @@
 #' \code{hover.data} argument is used to determine what data to use.
 #' @param hover.data String vector of gene and metadata names, example: \code{c("meta1","gene1","meta2")} which determines what data to show on hover when \code{do.hover} is set to \code{TRUE}.
 #' @param hover.assay,hover.slot,hover.adjustment Similar to the non-hover versions of these inputs, when showing expression data upon hover, these set what data will be shown.
+#' @param height Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
+#' @param width Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
 #' @param add.trajectory.lineages List of vectors representing trajectory paths, each from start-cluster to end-cluster, where vector contents are the names of clusters provided in the \code{trajectory.cluster.meta} input.
 #'
 #' If the \code{\link[slingshot]{slingshot}} package was used for trajectory analysis,
@@ -300,6 +302,8 @@ dittoDimPlot <- function(
     hover.assay = .default_assay(object),
     hover.slot = .default_slot(object),
     hover.adjustment = NULL,
+    height = NULL,
+    width = NULL,
     add.trajectory.lineages = NULL,
     add.trajectory.curves = NULL,
     trajectory.cluster.meta,
@@ -354,6 +358,7 @@ dittoDimPlot <- function(
         min.color, max.color, min, max, order,
         xlab, ylab, main, sub, theme,
         do.hover, hover.data, hover.assay, hover.slot, hover.adjustment,
+        height, width,
         do.contour, contour.color, contour.linetype,
         add.trajectory.lineages, add.trajectory.curves = NULL,
         trajectory.cluster.meta, trajectory.arrow.size,
@@ -378,7 +383,7 @@ dittoDimPlot <- function(
     
     if (do.hover) {
         .error_if_no_plotly()
-        p <- plotly::ggplotly(p, tooltip = "text")
+        p <- plotly::ggplotly(p, height = height, width = width, tooltip = "text")
     }
     
     ### RETURN the PLOT ###

--- a/R/DittoScatterPlot.R
+++ b/R/DittoScatterPlot.R
@@ -36,6 +36,8 @@
 #' \code{hover.data} argument is used to determine what data to use.
 #' @param hover.data String vector of gene and metadata names, example: \code{c("meta1","gene1","meta2","gene2")} which determines what data to show on hover when \code{do.hover} is set to \code{TRUE}.
 #' @param hover.assay,hover.slot,hover.adjustment Similar to the x, y, color, and extra versions, when showing expression data upon hover, these set what data will be shown.
+#' @param height Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
+#' @param width Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
 #' @param shape.panel Vector of integers corresponding to ggplot shapes which sets what shapes to use.
 #' When discrete groupings are supplied by \code{shape.by}, this sets the panel of shapes.
 #' When nothing is supplied to \code{shape.by}, only the first value is used.
@@ -208,6 +210,8 @@ dittoScatterPlot <- function(
     hover.assay = .default_assay(object),
     hover.slot = .default_slot(object),
     hover.adjustment = NULL,
+    height = NULL,
+    width = NULL,
     do.contour = FALSE,
     contour.color = "black",
     contour.linetype = 1,
@@ -309,7 +313,7 @@ dittoScatterPlot <- function(
     
     if (do.hover) {
         .error_if_no_plotly()
-        p <- plotly::ggplotly(p, tooltip = "text")
+        p <- plotly::ggplotly(p, width = width, height = height, tooltip = "text")
     }
 
     ### RETURN the PLOT ###

--- a/R/dittoBarPlot.R
+++ b/R/dittoBarPlot.R
@@ -15,6 +15,8 @@
 #' (Provides an alternative to directly modifying \code{color.panel}.)
 #' @param scale "count" or "percent". Sets whether data should be shown as counts versus percentage.
 #' @param do.hover Logical which sets whether the ggplot output should be converted to a ggplotly object with data about individual bars displayed when you hover your cursor over them.
+#' @param height Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
+#' @param width Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
 #' @param theme A ggplot theme which will be applied before dittoSeq adjustments.
 #' Default = \code{theme_classic()}.
 #' See \url{https://ggplot2.tidyverse.org/reference/ggtheme.html} for other options and ideas.
@@ -130,6 +132,8 @@ dittoBarPlot <- function(
     retain.factor.levels = FALSE,
     data.out = FALSE,
     do.hover = FALSE,
+    height = NULL,
+    width = NULL,
     color.panel = dittoColors(),
     colors = seq_along(color.panel),
     split.nrow = NULL,
@@ -223,7 +227,7 @@ dittoBarPlot <- function(
     
     if (do.hover) {
         .error_if_no_plotly()
-        p <- plotly::ggplotly(p, tooltip = "text")
+        p <- plotly::ggplotly(p, height = height, width = width, tooltip = "text")
     }
 
     #DONE. Return the plot

--- a/R/dittoDotPlot.R
+++ b/R/dittoDotPlot.R
@@ -36,6 +36,8 @@
 #' @param legend.color.title,legend.size.title String or \code{NULL}, sets the title displayed above legend keys.
 #' @param do.hover Logical. Default = \code{FALSE}.
 #' If set to \code{TRUE} the object will be converted to an interactive plotly object in which underlying data for individual dots will be displayed when you hover your cursor over them.
+#' @param height Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
+#' @param width Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
 #'
 #' @inheritParams dittoPlotVarsAcrossGroups
 #' @inheritParams dittoScatterPlot
@@ -151,6 +153,8 @@ dittoDotPlot <- function(
     adjustment = NULL,
     swap.rownames = NULL,
     do.hover = FALSE,
+    height = NULL,
+    width = NULL,
     main = NULL,
     sub = NULL,
     ylab = group.by,
@@ -221,7 +225,7 @@ dittoDotPlot <- function(
 
     if (do.hover) {
         .error_if_no_plotly()
-        p <- plotly::ggplotly(p, tooltip = "text")
+        p <- plotly::ggplotly(p, height = height, width = width, tooltip = "text")
     }
     
     # DONE. Return

--- a/R/dittoPlot.R
+++ b/R/dittoPlot.R
@@ -41,6 +41,8 @@
 #' @param do.hover Logical. Default = \code{FALSE}.
 #' If set to \code{TRUE}: object will be converted to a ggplotly object so that data about individual cells will be displayed when you hover your cursor over the jitter points (assuming that there is a "jitter" in \code{plots}),
 #' @param hover.data String vector, a list of variable names, c("meta1","gene1","meta2",...) which determines what data to show upon hover when do.hover is set to \code{TRUE}.
+#' @param height Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
+#' @param width Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
 #' @param color.panel String vector which sets the colors to draw from for plot fills.
 #' Default = \code{dittoColors()}.
 #' @param colors Integer vector, the indexes / order, of colors from color.panel to actually use.
@@ -89,7 +91,6 @@
 #' @param jitter.shape.legend.show Logical which sets whether the shapes legend will be shown when its shape is determined by \code{shape.by}.
 #' @param jitter.position.dodge Scalar which adjusts the relative distance between jitter widths when multiple subgroups exist per \code{group.by} grouping (a.k.a. when \code{group.by} and \code{color.by} are not equal).
 #' Similar to \code{boxplot.position.dodge} input & defaults to the value of that input so that BOTH will actually be adjusted when only, say, \code{boxplot.position.dodge = 0.3} is given.
-#' @param do.raster Logical. When set to \code{TRUE}, rasterizes the jitter plot layer, changing it from individually encoded points to a flattened set of pixels.
 #' @param do.raster Logical. When set to \code{TRUE}, rasterizes the jitter plot layer, changing it from individually encoded points to a flattened set of pixels.
 #' This can be useful for editing in external programs (e.g. Illustrator) when there are many thousands of data points.
 #' @param raster.dpi Number indicating dots/pixels per inch (dpi) to use for rasterization. Default = 300.
@@ -248,6 +249,8 @@ dittoPlot <- function(
     swap.rownames = NULL,
     do.hover = FALSE,
     hover.data = var,
+    height = NULL,
+    width = NULL,
     color.panel = dittoColors(),
     colors = seq_along(color.panel),
     shape.panel = c(16,15,17,23,25,8),
@@ -357,7 +360,7 @@ dittoPlot <- function(
     }
     
     if (do.hover) {
-        p <- .warn_or_jitter_plotly(p, plots)
+        p <- .warn_or_jitter_plotly(p, height, width, plots)
     }
     
     # DONE. Return the plot +/- data
@@ -574,16 +577,16 @@ dittoBoxPlot <- function(..., plots = c("boxplot","jitter")){ dittoPlot(..., plo
     p
 }
 
-.warn_or_jitter_plotly <- function(p, plots) {
+.warn_or_jitter_plotly <- function(p, height, width, plots) {
     if ("ridgeplot" %in% plots) {
         warning("'do.hover = TRUE' request ignored because plotly does not support ridgeplots.")
     } else {
         .error_if_no_plotly()
         # Add hover.text to jitter, else just convert.
         if ("jitter" %in% plots) {
-            p <- plotly::ggplotly(p, tooltip = "text")
+            p <- plotly::ggplotly(p, height = height, width = width, tooltip = "text")
         } else {
-            p <- plotly::ggplotly(p)
+            p <- plotly::ggplotly(p, height = height, width = width)
         }
     }
     p

--- a/R/dittoPlotVarsAcrossGroups.R
+++ b/R/dittoPlotVarsAcrossGroups.R
@@ -24,6 +24,8 @@
 #' }
 #' @param do.hover Logical. Default = \code{FALSE}.
 #' If set to \code{TRUE} (and if there is a "jitter" in \code{plots}): the object will be converted to a plotly object in which underlying data about individual points will be displayed when you hover your cursor over them.
+#' @param height Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
+#' @param width Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise. 
 #' @param color.panel String vector which sets the colors to draw from for plot fills.
 #' @param colors Integer vector, the indexes / order, of colors from color.panel to actually use.
 #' (Provides an alternative to directly modifying \code{color.panel}.)
@@ -149,6 +151,8 @@ dittoPlotVarsAcrossGroups <- function(
     adjustment = "z-score",
     swap.rownames = NULL,
     do.hover = FALSE,
+    height = NULL,
+    width = NULL,
     main = NULL,
     sub = NULL,
     ylab = "make",
@@ -261,7 +265,7 @@ dittoPlotVarsAcrossGroups <- function(
     }
     
     if (do.hover) {
-        p <- .warn_or_jitter_plotly(p, plots)
+        p <- .warn_or_jitter_plotly(p, height = height, width = width, plots)
     }
     
     # DONE. Return the plot +/- data

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,10 @@
 \title{dittoSeq News}
 \encoding{UTF-8}
 
+\section{Version 1.5.2}{\itemize{
+\item Added `height` and `width` input to control plot size when `do.hover` is used.
+}}
+
 \section{Version 1.5.1}{\itemize{
 \item Build & Test Infrastructure Fix/Update: Removes the remaining Seurat code from the vignette and makes all unit-testing of Seurat interactions conditional on SCE to Seurat cnversion.
 \item Vignette Update: Adds a 'Quick-Reference: Seurat<=>dittoSeq' section

--- a/man/dittoBarPlot.Rd
+++ b/man/dittoBarPlot.Rd
@@ -14,6 +14,8 @@ dittoBarPlot(
   retain.factor.levels = FALSE,
   data.out = FALSE,
   do.hover = FALSE,
+  height = NULL,
+  width = NULL,
   color.panel = dittoColors(),
   colors = seq_along(color.panel),
   split.nrow = NULL,
@@ -64,6 +66,10 @@ but Note that this will also force retention of groupings that could otherwise b
 \item{data.out}{Logical. When set to \code{TRUE}, changes the output, from the plot alone, to a list containing the plot ("p") and a data.frame ("data") containing the underlying data.}
 
 \item{do.hover}{Logical which sets whether the ggplot output should be converted to a ggplotly object with data about individual bars displayed when you hover your cursor over them.}
+
+\item{height}{Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
+
+\item{width}{Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
 
 \item{color.panel}{String vector which sets the colors to draw from. \code{dittoColors()} by default.}
 

--- a/man/dittoDimPlot.Rd
+++ b/man/dittoDimPlot.Rd
@@ -55,6 +55,8 @@ dittoDimPlot(
   hover.assay = .default_assay(object),
   hover.slot = .default_slot(object),
   hover.adjustment = NULL,
+  height = NULL,
+  width = NULL,
   add.trajectory.lineages = NULL,
   add.trajectory.curves = NULL,
   trajectory.cluster.meta,
@@ -214,6 +216,10 @@ Defaults to \code{split.by}, so generally there is no need to adjust this except
 \item{hover.data}{String vector of gene and metadata names, example: \code{c("meta1","gene1","meta2")} which determines what data to show on hover when \code{do.hover} is set to \code{TRUE}.}
 
 \item{hover.assay, hover.slot, hover.adjustment}{Similar to the non-hover versions of these inputs, when showing expression data upon hover, these set what data will be shown.}
+
+\item{height}{Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
+
+\item{width}{Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
 
 \item{add.trajectory.lineages}{List of vectors representing trajectory paths, each from start-cluster to end-cluster, where vector contents are the names of clusters provided in the \code{trajectory.cluster.meta} input.
 

--- a/man/dittoDotPlot.Rd
+++ b/man/dittoDotPlot.Rd
@@ -25,6 +25,8 @@ dittoDotPlot(
   adjustment = NULL,
   swap.rownames = NULL,
   do.hover = FALSE,
+  height = NULL,
+  width = NULL,
   main = NULL,
   sub = NULL,
   ylab = group.by,
@@ -91,6 +93,10 @@ Any function can be used as long as it takes in a numeric vector and returns a s
 
 \item{do.hover}{Logical. Default = \code{FALSE}.
 If set to \code{TRUE} the object will be converted to an interactive plotly object in which underlying data for individual dots will be displayed when you hover your cursor over them.}
+
+\item{height}{Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
+
+\item{width}{Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
 
 \item{main}{String which sets the plot title.}
 

--- a/man/dittoPlot.Rd
+++ b/man/dittoPlot.Rd
@@ -23,6 +23,8 @@ dittoPlot(
   swap.rownames = NULL,
   do.hover = FALSE,
   hover.data = var,
+  height = NULL,
+  width = NULL,
   color.panel = dittoColors(),
   colors = seq_along(color.panel),
   shape.panel = c(16, 15, 17, 23, 25, 8),
@@ -124,6 +126,10 @@ See details section for more info.}
 If set to \code{TRUE}: object will be converted to a ggplotly object so that data about individual cells will be displayed when you hover your cursor over the jitter points (assuming that there is a "jitter" in \code{plots}),}
 
 \item{hover.data}{String vector, a list of variable names, c("meta1","gene1","meta2",...) which determines what data to show upon hover when do.hover is set to \code{TRUE}.}
+
+\item{height}{Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
+
+\item{width}{Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
 
 \item{color.panel}{String vector which sets the colors to draw from for plot fills.
 Default = \code{dittoColors()}.}

--- a/man/dittoPlotVarsAcrossGroups.Rd
+++ b/man/dittoPlotVarsAcrossGroups.Rd
@@ -18,6 +18,8 @@ dittoPlotVarsAcrossGroups(
   adjustment = "z-score",
   swap.rownames = NULL,
   do.hover = FALSE,
+  height = NULL,
+  width = NULL,
   main = NULL,
   sub = NULL,
   ylab = "make",
@@ -105,6 +107,10 @@ See details section for more info.}
 
 \item{do.hover}{Logical. Default = \code{FALSE}.
 If set to \code{TRUE} (and if there is a "jitter" in \code{plots}): the object will be converted to a plotly object in which underlying data about individual points will be displayed when you hover your cursor over them.}
+
+\item{height}{Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
+
+\item{width}{Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
 
 \item{main}{String which sets the plot title.}
 

--- a/man/dittoScatterPlot.Rd
+++ b/man/dittoScatterPlot.Rd
@@ -53,6 +53,8 @@ dittoScatterPlot(
   hover.assay = .default_assay(object),
   hover.slot = .default_slot(object),
   hover.adjustment = NULL,
+  height = NULL,
+  width = NULL,
   do.contour = FALSE,
   contour.color = "black",
   contour.linetype = 1,
@@ -172,6 +174,10 @@ See \url{https://ggplot2.tidyverse.org/reference/ggtheme.html} for other options
 \item{hover.data}{String vector of gene and metadata names, example: \code{c("meta1","gene1","meta2","gene2")} which determines what data to show on hover when \code{do.hover} is set to \code{TRUE}.}
 
 \item{hover.assay, hover.slot, hover.adjustment}{Similar to the x, y, color, and extra versions, when showing expression data upon hover, these set what data will be shown.}
+
+\item{height}{Number that sets height of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
+
+\item{width}{Number that sets width of plot in pixels when \code{do.hover} is set to \code{TRUE}. Ignored otherwise.}
 
 \item{do.contour}{Logical. Whether density-based contours should be displayed.}
 


### PR DESCRIPTION
Addresses #88.

Also remove duplicated parameter doc line in `dittoPlot.R`.

Didn't add tests since the interactive tests were relatively sparse already. Checks passed.