### PR TITLE
Bug Fix: Allow `dittoHeatmap()` to properly `drop_levels` of annotations by adjusting color-picking.

### DIFF
--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -379,10 +379,10 @@ dittoHeatmap <- function(
     args$mat <- args$mat/maxs
     args$scale <- "none"
     args$color <- heatmap.colors.max.scaled
-    if (is.na(args$legend_breaks)) {
+    if (identical(args$legend_breaks, NA)) {
         args$legend_breaks <- seq(0, 1, 0.2)
     }
-    if (is.na(args$breaks)) {
+    if (identical(args$breaks, NA)) {
         args$breaks <- seq(0, 1, length.out = length(args$color)+1)
     }
 

--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -31,7 +31,7 @@
 #' (Can be useful for troubleshooting or customization.)
 #' @param highlight.features String vector of genes/metadata whose names you would like to show. Only these genes/metadata will be named in the resulting heatmap.
 #' @param highlight.genes Deprecated, use \code{highlight.features} instead.
-#' @param cluster_cols,border_color,legend_breaks,breaks,... other arguments passed to \code{\link[pheatmap]{pheatmap}} directly (or to \code{\link[ComplexHeatmap]{pheatmap}} if \code{complex = TRUE}).
+#' @param cluster_cols,border_color,legend_breaks,breaks,drop_levels,... other arguments passed to \code{\link[pheatmap]{pheatmap}} directly (or to \code{\link[ComplexHeatmap]{pheatmap}} if \code{complex = TRUE}).
 #' @param show_colnames,show_rownames,scale,annotation_col,annotation_colors arguments passed to \code{pheatmap} that are over-ruled by certain \code{dittoHeatmap} functionality:
 #' \itemize{
 #' \item show_colnames (& labels_col): if \code{cell.names.meta} is provided, pheatmaps's \code{labels_col} is utilized to show these names and \code{show_colnames} parameter is set to \code{TRUE}.
@@ -220,6 +220,7 @@ dittoHeatmap <- function(
     cluster_cols = isBulk(object),
     border_color = NA,
     legend_breaks = NA,
+    drop_levels = FALSE,
     breaks = NA,
     complex = FALSE,
     ...) {
@@ -291,12 +292,13 @@ dittoHeatmap <- function(
         heatmap.colors, scaled.to.max, heatmap.colors.max.scaled, annot.colors,
         annotation_col, annotation_colors, highlight.features, show_colnames,
         show_rownames, scale, cluster_cols, border_color, legend_breaks,
-        breaks, ...)
+        drop_levels, breaks, ...)
     
     if (data.out) {
         OUT <- args
     } else if (complex) {
         .error_if_no_complexHm()
+        args <- .adjust_for_complex(args)
         OUT <- do.call("pheatmap", args, envir = asNamespace("ComplexHeatmap"))
     } else {
         OUT <- do.call(pheatmap::pheatmap, args)
@@ -323,6 +325,7 @@ dittoHeatmap <- function(
     cluster_cols,
     border_color,
     legend_breaks,
+    drop_levels,
     breaks,
     ...) {
     
@@ -331,7 +334,8 @@ dittoHeatmap <- function(
         mat = data, main = main, show_colnames = show_colnames,
         show_rownames = show_rownames, color = heatmap.colors,
         cluster_cols = cluster_cols, border_color = border_color,
-        scale = scale, breaks = breaks, legend_breaks = legend_breaks, ...)
+        scale = scale, breaks = breaks, legend_breaks = legend_breaks,
+        drop_levels = drop_levels, ...)
     
     # Adjust data
     
@@ -346,7 +350,7 @@ dittoHeatmap <- function(
         }
         args$annotation_colors <- annotation_colors
         # Add any missing annotation colors
-        args <- .make_heatmap_annotation_colors(args, annot.colors)
+        args <- .make_heatmap_annotation_colors(args, annot.colors, drop_levels)
     }
 
     # Make a labels_row input for displaying only certain genes/variables if given to 'highlight.features'
@@ -389,7 +393,7 @@ dittoHeatmap <- function(
     # list of character vectors, all named.
         # vector names = annotation titles
         # vector members' (colors') names = annotation identities
-.make_heatmap_annotation_colors <- function(args, annot.colors) {
+.make_heatmap_annotation_colors <- function(args, annot.colors, drop_levels) {
 
     # Extract a default color-set
     annot.colors.d <- annot.colors
@@ -409,7 +413,7 @@ dittoHeatmap <- function(
             dfcolors_out <- .pick_colors_for_df(
                 args$annotation_col[,make.these, drop = FALSE],
                 next.color.index.discrete, next.color.index.numeric,
-                annot.colors.d, annot.colors.n)
+                annot.colors.d, annot.colors.n, drop_levels)
             col_colors <- dfcolors_out$df_colors
             next.color.index.discrete <- dfcolors_out$next.color.index.discrete
             next.color.index.numeric <- dfcolors_out$next.color.index.numeric
@@ -423,7 +427,7 @@ dittoHeatmap <- function(
             dfcolors_out <- .pick_colors_for_df(
                 args$annotation_row[,make.these, drop = FALSE],
                 next.color.index.discrete, next.color.index.numeric,
-                annot.colors.d, annot.colors.n)
+                annot.colors.d, annot.colors.n, drop_levels)
             row_colors <- dfcolors_out$df_colors
         }
     }
@@ -440,7 +444,7 @@ dittoHeatmap <- function(
 .pick_colors_for_df <- function(
     annotation_df,
     next.color.index.discrete, next.color.index.numeric,
-    annot.colors.d, annot.colors.n
+    annot.colors.d, annot.colors.n, drop_levels
     ) {
 
     df_colors <- list()
@@ -450,6 +454,10 @@ dittoHeatmap <- function(
         if(!is.numeric(annotation_df[,i])){
             # Discrete, determine the distinct contents of the annotation first
             in.this.annot <- levels(as.factor(annotation_df[,i]))
+            if(drop_levels){
+                levels.with.data <- unique(as.character(annotation_df[,i]))
+                in.this.annot <- in.this.annot[in.this.annot %in% levels.with.data]
+            }
             
             # Take colors for each, and name them.
             new.colors <- annot.colors.d[
@@ -504,4 +512,15 @@ dittoHeatmap <- function(
     } 
 
     data
+}
+
+.adjust_for_complex <- function(args) {
+
+    # As of Sept 2021, CH complains when 'drop_levels' is given because its
+    # maintainer decided to enforced the input to always be TRUE.  We still get
+    # the effect via the 'annotation_colors' setup, so it should be safe to
+    # simply remove the input before passing along.
+    args$drop_levels <- NULL
+
+    args
 }

--- a/man/dittoHeatmap.Rd
+++ b/man/dittoHeatmap.Rd
@@ -31,6 +31,7 @@ dittoHeatmap(
   cluster_cols = isBulk(object),
   border_color = NA,
   legend_breaks = NA,
+  drop_levels = FALSE,
   breaks = NA,
   complex = FALSE,
   ...
@@ -92,7 +93,7 @@ Default is a ramp from white to red with 25 slices.}
 but it is possible to set all or some manually. dittoSeq will just fill any left out annotations. Format is a named (annotation_col & annotation_row colnames) character vector list where individual color values can also be named.
 }}
 
-\item{cluster_cols, border_color, legend_breaks, breaks, ...}{other arguments passed to \code{\link[pheatmap]{pheatmap}} directly (or to \code{\link[ComplexHeatmap]{pheatmap}} if \code{complex = TRUE}).}
+\item{cluster_cols, border_color, legend_breaks, breaks, drop_levels, ...}{other arguments passed to \code{\link[pheatmap]{pheatmap}} directly (or to \code{\link[ComplexHeatmap]{pheatmap}} if \code{complex = TRUE}).}
 
 \item{complex}{Logical which sets whether the heatmap should be generated with ComplexHeatmap (\code{TRUE}) versus pheatmap (\code{FALSE}, default).}
 }
@@ -205,7 +206,7 @@ dittoHeatmap(myRNA, genes,
     annot.by = "clustering",
     order.by = "clustering",
     cluster_cols = FALSE)
-# 'order.by' can be multiple metadata/genes, or a vector of indexes directly 
+# 'order.by' can be multiple metadata/genes, or a vector of indexes directly
 dittoHeatmap(scRNA, genes,
     annot.by = "clustering",
     order.by = c("clustering", "timepoint"))

--- a/man/dittoHeatmap.Rd
+++ b/man/dittoHeatmap.Rd
@@ -206,7 +206,7 @@ dittoHeatmap(myRNA, genes,
     annot.by = "clustering",
     order.by = "clustering",
     cluster_cols = FALSE)
-# 'order.by' can be multiple metadata/genes, or a vector of indexes directly
+# 'order.by' can be multiple metadata/genes, or a vector of indexes directly 
 dittoHeatmap(scRNA, genes,
     annot.by = "clustering",
     order.by = c("clustering", "timepoint"))

--- a/tests/testthat/test-Heatmap-complex.R
+++ b/tests/testthat/test-Heatmap-complex.R
@@ -11,12 +11,12 @@ test_that("Heatmap can be plotted for SCE, both genes and metas", {
         dittoHeatmap(complex = TRUE,
             genes = genes,
             object = sce),
-        "HeatmapList")
+        "Heatmap")
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             metas = metas,
             object = sce),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap data type can be adjusted", {
@@ -25,7 +25,7 @@ test_that("Heatmap data type can be adjusted", {
             genes = genes,
             object = sce,
             assay = "counts"),
-        "HeatmapList")
+        "Heatmap")
 })
 
 # Set genes1:5 to have all zeros in logcounts in a new object
@@ -100,7 +100,7 @@ test_that("Heatmap title can be adjusted", {
             genes = genes,
             object = sce,
             main = "Hello there!"),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap sample renaming by metadata works", {
@@ -110,7 +110,7 @@ test_that("Heatmap sample renaming by metadata works", {
             genes = genes,
             object = sce,
             cell.names.meta = "number"),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap can hide rownames/colnames", {
@@ -120,14 +120,14 @@ test_that("Heatmap can hide rownames/colnames", {
             genes = genes,
             object = sce,
             show_colnames = TRUE),
-        "HeatmapList")
+        "Heatmap")
     ### No rownames
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
             genes = genes,
             object = sce,
             show_rownames = FALSE),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap highlight genes works", {
@@ -139,7 +139,7 @@ test_that("Heatmap highlight genes works", {
             show_colnames = FALSE,
             show_rownames = FALSE,
             highlight.features = "gene1"),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap can be scaled to max", {
@@ -149,7 +149,7 @@ test_that("Heatmap can be scaled to max", {
             genes = genes,
             object = sce,
             scaled.to.max = TRUE),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap colors can be adjusted", {
@@ -159,7 +159,7 @@ test_that("Heatmap colors can be adjusted", {
             genes = genes,
             object = sce,
             heatmap.colors = colorRampPalette(c("yellow", "black", "red"))(50)),
-        "HeatmapList")
+        "Heatmap")
     ### black to yellow, 0:1
     expect_s4_class(
         dittoHeatmap(complex = TRUE,
@@ -167,7 +167,7 @@ test_that("Heatmap colors can be adjusted", {
             object = sce,
             scaled.to.max = TRUE,
             heatmap.colors.max.scaled = colorRampPalette(c("black", "yellow"))(25)),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap annotations can be given & heatmaps can be ordered by metadata, expression, or user-input vector", {
@@ -178,7 +178,7 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
             genes = genes,
             object = sce,
             order.by = "gene1"),
-        "HeatmapList")
+        "Heatmap")
     # Works for metadata
     ### ordered by groups
     expect_s4_class(
@@ -187,7 +187,7 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
             object = sce,
             order.by = "groups",
             annot.by = "groups"),
-        "HeatmapList")
+        "Heatmap")
     # Works with vectors provided
     ### Ordered in REVERSE of number2
     expect_s4_class(
@@ -196,7 +196,7 @@ test_that("Heatmap annotations can be given & heatmaps can be ordered by metadat
             object = sce,
             annot.by = "number2",
             order.by = seq_along(colnames(sce))),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap annotations can be given & ordering can be adjusted and follows defaults", {
@@ -207,7 +207,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
             genes = genes,
             object = sce,
             annot.by = "clusters"),
-        "HeatmapList")
+        "Heatmap")
     # Samples should not be ordered by this (bulk)
     ### CLustered
     expect_s4_class(
@@ -215,7 +215,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
             genes = genes,
             object = bulk,
             annot.by = "clusters"),
-        "HeatmapList")
+        "Heatmap")
     # Clusters even though an order.by would be given
     ### Clustered!
     expect_s4_class(
@@ -224,7 +224,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
             object = sce,
             annot.by = "clusters",
             cluster_cols = TRUE),
-        "HeatmapList")
+        "Heatmap")
     # Ordering, but distinct from the first annotation
     ### ordered by groups.
     expect_s4_class(
@@ -233,7 +233,7 @@ test_that("Heatmap annotations can be given & ordering can be adjusted and follo
             object = sce,
             annot.by = c("clusters", "groups"),
             order.by = "groups"),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap can be ordered when also subset to certain cells", {
@@ -245,7 +245,7 @@ test_that("Heatmap can be ordered when also subset to certain cells", {
             object = sce,
             order.by = "gene1",
             cells.use = meta("number", sce)<20),
-        "HeatmapList")
+        "Heatmap")
     # Works for metadata
     ### ordered by groups metadata
     expect_s4_class(
@@ -254,7 +254,7 @@ test_that("Heatmap can be ordered when also subset to certain cells", {
             object = sce,
             annot.by = "groups",
             cells.use = colnames(sce)[meta("number", sce)<20]),
-        "HeatmapList")
+        "Heatmap")
     # Works with vectors provided
     ### ordered in REVERSE of the number annotations
     expect_s4_class(
@@ -264,7 +264,7 @@ test_that("Heatmap can be ordered when also subset to certain cells", {
             annot.by = "number2",
             order.by = seq_along(colnames(sce)),
             cells.use = colnames(sce)[meta("number", sce)<20]),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap can be subset to certain cells by any method", {
@@ -275,7 +275,7 @@ test_that("Heatmap can be subset to certain cells by any method", {
             genes = genes,
             object = sce,
             cells.use = meta("number", sce)<10), # Logical method
-        "HeatmapList")
+        "Heatmap")
     # By names
     ### Same few cells
     expect_s4_class(
@@ -283,7 +283,7 @@ test_that("Heatmap can be subset to certain cells by any method", {
             genes = genes,
             object = sce,
             cells.use = colnames(sce)[meta("number", sce)<10]), # names method
-        "HeatmapList")
+        "Heatmap")
     # By indices
     ### Same few cells
     expect_s4_class(
@@ -291,7 +291,7 @@ test_that("Heatmap can be subset to certain cells by any method", {
             genes = genes,
             object = sce,
             cells.use = 1:9), # names method
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap annotation colors can be adjusted via annot.colors", {
@@ -304,7 +304,7 @@ test_that("Heatmap annotation colors can be adjusted via annot.colors", {
             object = sce,
             annot.by = c("number","clusters"),
             annot.colors = c("red", "yellow", "blue", "purple", "green3")),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Heatmap annotation colors can be adjusted via annotation_colors", {
@@ -321,7 +321,7 @@ test_that("Heatmap annotation colors can be adjusted via annotation_colors", {
             object = sce,
             annot.by = c("number","clusters"),
             annotation_colors = color_list),
-        "HeatmapList")
+        "Heatmap")
     ### When annotation_colors provides all colors for annotation_col.
     color_list <- list(clusters = c('1' = "red",
                                     '2' = "yellow",
@@ -333,7 +333,7 @@ test_that("Heatmap annotation colors can be adjusted via annotation_colors", {
             object = sce,
             annot.by = c("clusters"),
             annotation_colors = color_list),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Coloring works for discrete column and row annotations", {
@@ -347,7 +347,7 @@ test_that("Coloring works for discrete column and row annotations", {
             annotation_row = data.frame(
                 genes,
                 row.names = genes)),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Coloring works for continuous column and row annotations", {
@@ -363,7 +363,7 @@ test_that("Coloring works for continuous column and row annotations", {
                 row.names = genes),
             cluster_rows = FALSE,
             cluster_cols = FALSE),
-        "HeatmapList")
+        "Heatmap")
     ### column and row annotations, all numeric.
     ### but column annotation bar flips, while legend stays the same.
     expect_s4_class(
@@ -378,18 +378,18 @@ test_that("Coloring works for continuous column and row annotations", {
                 row.names = genes),
             cluster_rows = FALSE,
             cluster_cols = FALSE),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("scale and border_color pheatmap inputs function as expected", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE,genes = genes, object = sce,
             scale = "none"),
-        "HeatmapList")
+        "Heatmap")
     expect_s4_class(
         dittoHeatmap(complex = TRUE,genes = genes, object = sce,
             border_color = "red"),
-        "HeatmapList")
+        "Heatmap")
 })
 
 test_that("Rasterization works for ComplexHeatmap", {
@@ -397,5 +397,17 @@ test_that("Rasterization works for ComplexHeatmap", {
     expect_s4_class(
         dittoHeatmap(complex = TRUE, genes = genes, object = sce,
             use_raster = TRUE, raster_quality = 1),
-        "HeatmapList")
+        "Heatmap")
+})
+
+test_that("dittoHeatmap drop_level dropped from args when complex = TRUE",{
+    args <- dittoHeatmap(genes = genes, object = sce, data.out = TRUE,
+        drop_levels = TRUE, complex = TRUE)
+    
+    # Manual Check: Only three colors in the legend
+    expect_warning(
+        dittoHeatmap(genes = genes, object = sce,
+            annot.by = "clusters", cells.use = sce$clusters!="4",
+            drop_levels = TRUE, complex = TRUE),
+        NA)
 })

--- a/tests/testthat/test-Heatmap.R
+++ b/tests/testthat/test-Heatmap.R
@@ -424,3 +424,21 @@ test_that("dittoHeatmap swap.rownames works", {
             )$mat),
         swap_genes)
 })
+
+test_that("dittoHeatmap drops levles from annotation_colors to allow 'drop_levels' to function",{
+    full <- dittoHeatmap(genes = genes, object = sce, data.out = TRUE,
+        annot.by = "clusters", cells.use = sce$clusters!="4",
+        drop_levels = FALSE)$annotation_colors$clusters
+    dropped <- dittoHeatmap(genes = genes, object = sce, data.out = TRUE,
+        annot.by = "clusters", cells.use = sce$clusters!="4",
+        drop_levels = TRUE)$annotation_colors$clusters
+    
+    expect_equal(length(full), length(dropped)+1)
+    
+    # Manual Check: Only three colors in the legend
+    expect_s3_class(
+        dittoHeatmap(genes = genes, object = sce,
+            annot.by = "clusters", cells.use = sce$clusters!="4",
+            drop_levels = TRUE),
+        "pheatmap")
+})


### PR DESCRIPTION
Addresses #95

Note: Users will need to adjust this input deliberately when they want levels to be dropped.  The default for `drop_levels` in `dittoHeatmap()` will be set to FALSE.  This is contrary to the `pheatmap()` function itself, but should allow for consistency both 1) across plots when users might make a bunch of plots at once while not realizing that say "conditionX is the only condition without any samples from groupB", as well as 2) with previous dittoSeq outputs.

Still to do:
- [x] add unit test
- [ ] prep NEWS update for after merge