### PR TITLE
Add an error when the supplied `object` doesn't have cell/column names.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Description: A universal, user friendly, single-cell and bulk RNA sequencing
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Depends: ggplot2
 Imports: methods,
     colorspace (>= 1.4),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dittoSeq
 Type: Package
 Title: User Friendly Single-Cell and Bulk RNA Sequencing Visualization
-Version: 1.9.0
+Version: 1.9.1
 Authors@R: c(person("Daniel", "Bunis", email = "daniel.bunis@ucsf.edu", role=c("aut", "cre")),
     person("Jared", "Andrews", email = "jared.andrews07@gmail.com", role=c("aut", "ctb")))
 Description: A universal, user friendly, single-cell and bulk RNA sequencing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dittoSeq 1.9.1
+
+* Added a helpful error message to catch cases where 'object' does not have cell/column names, and suggest how to add them.
+
 # dittoSeq 1.8
 
 * Minor Feature Add: 'randomize' option for 'order' input of 'dittoDimPlot()' and 'dittoScatterPlot()'
@@ -5,7 +9,7 @@
 # dittoSeq 1.6
 
 * Vignette Update: Added a 'Quick-Reference: Seurat<=>dittoSeq' section.
-* Build & Test Infrastructure Update: Removed Seurat dependency from all build and test materials by removing Seurat code from the vignette and making all unit-testing of Seurat interactions conditional on both presence of Seurat and successful SCE to Seurat cnversion.
+* Build & Test Infrastructure Update: Removed Seurat dependency from all build and test materials by removing Seurat code from the vignette and making all unit-testing of Seurat interactions conditional on both presence of Seurat and successful SCE to Seurat conversion.
 * Bug Fixes:
 1- Fixed dittoFreqPlot calculation machinery to properly target all cell types but only necessary groupings for every sample. Removed the 'retain.factor.levels' input because proper calculations treat 'var'-data as a factor, and groupings data as non-factor.
 2- Allowed dittoHeatmap() to properly 'drop_levels' of annotations by ensuring 'annotation_colors' is not populated with colors for empty levels which would be dropped.
@@ -17,7 +21,7 @@
 * Added interaction with 'rowData' of SE and SCEs via a 'swap.rownames' input, e.g. to simplify provision of 'var's via symbols vs IDs.
 * Improved & expanded 'split.by' capabilities by:
 1- adding them to 'dittoBarPlot()', 'dittoDotPlot()', and 'dittoPlotVarsAcrossGroups()';
-2- adding 'split.adjust' input to all functions for passing adjudstments to underlying 'facet_grid()' and 'facet_wrap()' calls;
+2- adding 'split.adjust' input to all functions for passing adjustments to underlying 'facet_grid()' and 'facet_wrap()' calls;
 3- adding 'split.show.all.others' input to 'dittoDimPlot()' and 'dittoScatterPlot()' to allow the full spectrum of points, rather than just points excluded with 'cells.use', to be shown as light gray in the background of all facets;
 4- Bug fix: splitting now works with labeling of Dim/Scatter plots, with label position calculated per facet, and without affecting facet order.
 * Improved 'dittoPlot()'-plotting engine (also effects 'dittoPlotVarsAcrossGroups()', and 'dittoFreqPlot()') by:

--- a/R/utils-getters.R
+++ b/R/utils-getters.R
@@ -13,6 +13,13 @@
     # converts a 'cells.use' given as string, logical, or numeric vector
     # into the string vector format expected internally by dittoSeq functions
     all.cells <- .all_cells(object)
+    
+    if (is.null(all.cells)) {
+        stop(
+            "Given 'object' has no cell/column names, which will inhibit dittoSeq's data gathering functions. ",
+            "For most compatible 'object's, you can correct the issue with:\n    ",
+            "`colnames(<object>) <- paste0('cell', seq_len(ncol(<object>)))`")
+    }
 
     if (is.null(cells.use)) {
         # Returns all cells when 'cells.use' is NULL

--- a/man/dittoBarPlot.Rd
+++ b/man/dittoBarPlot.Rd
@@ -70,9 +70,7 @@ but Note that this will also force retention of groupings that could otherwise b
 \item{colors}{Integer vector, which sets the indexes / order, of colors from color.panel to actually use.
 (Provides an alternative to directly modifying \code{color.panel}.)}
 
-\item{split.nrow}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
-
-\item{split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
+\item{split.nrow, split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
 
 \item{split.adjust}{A named list which allows extra parameters to be pushed through to the faceting function call.
 List elements should be valid inputs to the faceting functions, e.g. `list(scales = "free")`.

--- a/man/dittoDimPlot.Rd
+++ b/man/dittoDimPlot.Rd
@@ -41,8 +41,12 @@ dittoDimPlot(
   rename.shape.groups = NULL,
   theme = theme_bw(),
   show.axes.numbers = TRUE,
-  show.grid.lines = if (is.character(reduction.use)) {     !grepl("umap|tsne",
-    tolower(reduction.use)) } else {     TRUE },
+  show.grid.lines = if (is.character(reduction.use)) {
+     !grepl("umap|tsne",
+    tolower(reduction.use))
+ } else {
+     TRUE
+ },
   do.letter = FALSE,
   do.ellipse = FALSE,
   do.label = FALSE,

--- a/man/dittoDotPlot.Rd
+++ b/man/dittoDotPlot.Rd
@@ -18,8 +18,12 @@ dittoDotPlot(
   max.color = "#C51B7D",
   min = "make",
   max = NULL,
-  summary.fxn.color = function(x) {     mean(x[x != 0]) },
-  summary.fxn.size = function(x) {     mean(x != 0) },
+  summary.fxn.color = function(x) {
+     mean(x[x != 0])
+ },
+  summary.fxn.size = function(x) {
+     mean(x != 0)
+ },
   assay = .default_assay(object),
   slot = .default_slot(object),
   adjustment = NULL,
@@ -76,9 +80,7 @@ Default = light grey and purple.}
 \item{summary.fxn.color, summary.fxn.size}{A function which sets how color or size will be used to summarize variables' data for each group.
 Any function can be used as long as it takes in a numeric vector and returns a single numeric value.}
 
-\item{assay}{single strings or integer that set which data to use when plotting expressin data. See \code{\link{gene}} for more information about how defaults for these are filled in when not provided.}
-
-\item{slot}{single strings or integer that set which data to use when plotting expressin data. See \code{\link{gene}} for more information about how defaults for these are filled in when not provided.}
+\item{assay, slot}{single strings or integer that set which data to use when plotting expressin data. See \code{\link{gene}} for more information about how defaults for these are filled in when not provided.}
 
 \item{adjustment}{When plotting gene expression (or antibody, or other forms of counts data), should that data be adjusted altogether before \code{cells.use} subsetting and splitting into groups?
 \itemize{
@@ -117,9 +119,7 @@ Set to \code{NULL} to remove.}
 
 \item{x.labels.rotate}{Logical which sets whether the var-labels should be rotated.}
 
-\item{split.nrow}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
-
-\item{split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
+\item{split.nrow, split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
 
 \item{split.adjust}{A named list which allows extra parameters to be pushed through to the faceting function call.
 List elements should be valid inputs to the faceting functions, e.g. `list(scales = "free")`.

--- a/man/dittoFreqPlot.Rd
+++ b/man/dittoFreqPlot.Rd
@@ -122,11 +122,7 @@ Default = \code{dittoColors()}.}
 
 \item{y.breaks}{Numeric vector, a set of breaks that should be used as major gridlines. c(break1,break2,break3,etc.).}
 
-\item{min}{Scalars which control the zoom of the plot.
-These inputs set the minimum / maximum values of the data to show.
-Default = set based on the limits of the data in var.}
-
-\item{max}{Scalars which control the zoom of the plot.
+\item{min, max}{Scalars which control the zoom of the plot.
 These inputs set the minimum / maximum values of the data to show.
 Default = set based on the limits of the data in var.}
 

--- a/man/dittoPlotVarsAcrossGroups.Rd
+++ b/man/dittoPlotVarsAcrossGroups.Rd
@@ -212,9 +212,7 @@ Defaults to "dashed", but any ggplot linetype will work.}
 
 \item{line.color}{String that sets the color(s) of the \code{add.line} line(s)}
 
-\item{split.nrow}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
-
-\item{split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
+\item{split.nrow, split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
 
 \item{split.adjust}{A named list which allows extra parameters to be pushed through to the faceting function call.
 List elements should be valid inputs to the faceting functions, e.g. `list(scales = "free")`.

--- a/tests/testthat/test-getters.R
+++ b/tests/testthat/test-getters.R
@@ -227,3 +227,27 @@ test_that(".which_cells errors when logical 'cells.use' is the wrong length", {
         "'cells.use' length must equal the number of cells/samples in 'object' when given in logical form",
         fixed = TRUE)
 })
+
+test_that(".which_cells errors when object is missing cell names", {
+    colnames(sce) <- NULL
+    expect_error(
+        .which_cells(NULL, sce),
+        "colnames(<object>)", fixed = TRUE
+    )
+
+    expect_error(
+        dittoPlot(
+            sce, "gene1", group.by = "groups"),
+        "colnames(<object>)", fixed = TRUE
+    )
+    expect_error(
+        dittoBarPlot(
+            sce, "clusters", group.by = "groups"),
+        "colnames(<object>)", fixed = TRUE
+    )
+    expect_error(
+        dittoDimPlot(
+            sce, "gene1"),
+        "colnames(<object>)", fixed = TRUE
+    )
+})


### PR DESCRIPTION
Addresses #102 and #108.

(Also updates roxygen version.)