### PR TITLE
Multi-var capabilities in `dittoPlot()` and perhaps other non-`multi_` plotters

### DIFF
--- a/R/DittoScatterPlot.R
+++ b/R/DittoScatterPlot.R
@@ -285,7 +285,7 @@ dittoScatterPlot <- function(
     ### Add extra features
     if (!is.null(split.by)) {
         p <- .add_splitting(
-            p, split.by, split.nrow, split.ncol, object, split.adjust)
+            p, split.by, split.nrow, split.ncol, split.adjust)
     }
     
     if (do.contour) {

--- a/R/dittoBarPlot.R
+++ b/R/dittoBarPlot.R
@@ -215,7 +215,7 @@ dittoBarPlot <- function(
     ### Add extra features
     if (!is.null(split.by)) {
         p <- .add_splitting(
-            p, split.by, split.nrow, split.ncol, object, split.adjust)
+            p, split.by, split.nrow, split.ncol, split.adjust)
     }
 
     if (!legend.show) {

--- a/R/dittoDotPlot.R
+++ b/R/dittoDotPlot.R
@@ -216,7 +216,7 @@ dittoDotPlot <- function(
     ### Add extra features
     if (!is.null(split.by)) {
         p <- .add_splitting(
-            p, split.by, split.nrow, split.ncol, object, split.adjust)
+            p, split.by, split.nrow, split.ncol, split.adjust)
     }
 
     if (do.hover) {

--- a/R/dittoFreqPlot.R
+++ b/R/dittoFreqPlot.R
@@ -300,7 +300,7 @@ dittoFreqPlot <- function(
     
     # Split by 'var' to have the desired per element effect!
     p <- .add_splitting(
-        p, "label", split.nrow, split.ncol, object, split.adjust)
+        p, "label", split.nrow, split.ncol, split.adjust)
     
     ### Add extra features
     if (!legend.show) {

--- a/R/dittoHex.R
+++ b/R/dittoHex.R
@@ -392,7 +392,7 @@ dittoScatterHex <- function(
     ### Add extra features
     if (!is.null(split.by)) {
         p <- .add_splitting(
-            p, split.by, split.nrow, split.ncol, object, split.adjust)
+            p, split.by, split.nrow, split.ncol, split.adjust)
     }
     
     if (do.contour) {

--- a/R/dittoPlotVarsAcrossGroups.R
+++ b/R/dittoPlotVarsAcrossGroups.R
@@ -253,7 +253,7 @@ dittoPlotVarsAcrossGroups <- function(
     ### Add extra features
     if (!is.null(split.by)) {
         p <- .add_splitting(
-            p, split.by, split.nrow, split.ncol, object, split.adjust)
+            p, split.by, split.nrow, split.ncol, split.adjust)
     }
     
     if (!legend.show) {

--- a/R/utils-getters.R
+++ b/R/utils-getters.R
@@ -79,7 +79,9 @@
     }
 
     if (length(OUT)!=length(cells)) {
-        stop("'var' is not a metadata or gene nor equal in length to ncol('object')")
+        stop(
+            ifelse(length(var)==1, var, 'var'),
+            " is not a metadata or gene nor equal in length to ncol('object')")
     }
     names(OUT) <- cells
     OUT

--- a/R/utils-plot-mods.R
+++ b/R/utils-plot-mods.R
@@ -1,4 +1,4 @@
-.add_splitting <- function(p, split.by, nrow, ncol, object, split.args) {
+.add_splitting <- function(p, split.by, nrow, ncol, split.args) {
     
     # Adds ggplot faceting to go with 'split.by' utilization.
 

--- a/man/dittoPlot.Rd
+++ b/man/dittoPlot.Rd
@@ -17,6 +17,7 @@ dittoPlot(
   extra.vars = NULL,
   cells.use = NULL,
   plots = c("jitter", "vlnplot"),
+  multivar.aes = c("split", "group", "color"),
   assay = .default_assay(object),
   slot = .default_slot(object),
   adjustment = NULL,
@@ -33,7 +34,7 @@ dittoPlot(
   y.breaks = NULL,
   min = NULL,
   max = NULL,
-  xlab = group.by,
+  xlab = "make",
   x.labels = NULL,
   x.labels.rotate = NA,
   x.reorder = NULL,
@@ -81,7 +82,8 @@ dittoBoxPlot(..., plots = c("boxplot", "jitter"))
 \item{object}{A Seurat, SingleCellExperiment, or SummarizedExperiment object.}
 
 \item{var}{Single string representing the name of a metadata or gene, OR a vector with length equal to the total number of cells/samples in the dataset.
-This is the data that will be displayed.}
+Alternatively, a string vector naming multiple genes or metadata.
+This is the primary data that will be displayed.}
 
 \item{group.by}{String representing the name of a metadata to use for separating the cells/samples into discrete groups.}
 
@@ -109,6 +111,8 @@ Alternatively, a Logical vector, the same length as the number of cells in the o
 Order matters: c("vlnplot", "boxplot", "jitter") will put a violin plot in the back, boxplot in the middle, and then individual dots in the front.
 
 See details section for more info.}
+
+\item{multivar.aes}{"split", "group", or "color", the plot feature to utilize for displaying 'var' value when \code{var} is given multiple genes or metadata.}
 
 \item{assay, slot}{single strings or integer that set which data to use when plotting gene expression / feature data. See \code{\link{gene}} for more information.}
 


### PR DESCRIPTION
Adds support for providing multiple genes/metadata to the `var` input of `dittoPlot()`, with a new input, `multivar.aes`, added to control how to display the var information.  Addresses #99 and #111.

The var information needs to be shown somewhere, which means overriding some aesthetic of the plot that dittoSeq already lets users control.  Thus, `multivar.aes` was added to give flexibility about which part of the plot gets used, so that users can hopefully still make their plot of choice.

**`multivar.aes` options:** (Data setup: `set.seed(42); example(importDittoBulk, echo = FALSE)`)
- "split" (default, so skipped here, `dittoPlot(object = myRNA, var = c("gene1", "gene2", "gene3"), group.by = "timepoint")`)
![image](https://user-images.githubusercontent.com/38870347/176735145-a0965bdf-730c-445d-9a73-e15fbb823223.png)
- "group" (`dittoPlot(object = myRNA, var = c("gene1", "gene2", "gene3"), group.by = "timepoint", multivar.aes = "group")`)
![image](https://user-images.githubusercontent.com/38870347/176735380-873f56a1-9fed-4a62-b431-435f921376d8.png)
- "color" (`dittoPlot(object = myRNA, var = c("gene1", "gene2", "gene3"), group.by = "timepoint", multivar.aes = "color")`)
![image](https://user-images.githubusercontent.com/38870347/176735487-656ab0f3-7fd8-43ba-bae8-77b2b7840306.png)

Still to do:
- [ ] Ensure satisfied with `multivar.aes` (Do I want to call it something else or add more options?)
- [ ] Unit tests
- [ ] Perhaps add to `dittoScatterPlot()`, `dittoDimPlot()` as well.