### PR TITLE
dittoDotPlot - respect group.by factor levels ordering 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Description: A universal, user friendly, single-cell and bulk RNA sequencing
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Depends: ggplot2
 Imports: methods,
     colorspace (>= 1.4),

--- a/R/DittoScatterPlot.R
+++ b/R/DittoScatterPlot.R
@@ -410,7 +410,7 @@ dittoScatterPlot <- function(
         
         p <- p +
             scale_shape_manual(
-                values = shape.panel[seq_along(levels(Target_data$shape))],
+                values = shape.panel[seq_along(levels(as.factor(Target_data$shape)))],
                 name = legend.shape.title) +
             guides(shape = guide_legend(override.aes = list(size=legend.shape.size)))
     

--- a/R/dittoDotPlot.R
+++ b/R/dittoDotPlot.R
@@ -361,6 +361,14 @@ dittoDotPlot <- function(
                     }
                 }
                 
+                # Respect factor level ordering of group.by
+                if (is.factor(groupings)) {
+                    new_data$grouping = factor(
+                        new_data$grouping,
+                        levels = levels(groupings)
+                    )
+                }
+                
                 new_data
             }
         )

--- a/R/dittoDotPlot.R
+++ b/R/dittoDotPlot.R
@@ -158,6 +158,7 @@ dittoDotPlot <- function(
     y.reorder = NULL,
     xlab = NULL,
     x.labels.rotate = TRUE,
+    groupings.drop.unused = TRUE,
     split.nrow = NULL,
     split.ncol = NULL,
     split.adjust = list(),
@@ -184,7 +185,8 @@ dittoDotPlot <- function(
         object, vars, group.by, split.by,
         list(summary.fxn.color, summary.fxn.size),
         c("color", "size"),
-        cells.use, assay, slot, adjustment, swap.rownames, do.hover)
+        cells.use, assay, slot, adjustment, swap.rownames, do.hover,
+        groupings.drop.unused)
     data$var <- factor(data$var, levels = vars)
     data$grouping <-
         .rename_and_or_reorder(data$grouping, y.reorder, y.labels)
@@ -303,6 +305,7 @@ dittoDotPlot <- function(
     adjustment,
     swap.rownames,
     do.hover,
+    groupings.drop.unused,
     numeric.only = TRUE) {
     
     object <- .swap_rownames(object, swap.rownames)
@@ -361,18 +364,16 @@ dittoDotPlot <- function(
                     }
                 }
                 
-                # Respect factor level ordering of group.by
-                if (is.factor(groupings)) {
-                    new_data$grouping = factor(
-                        new_data$grouping,
-                        levels = levels(groupings)
-                    )
-                }
-                
                 new_data
             }
         )
     )
+    
+    # Respect factor level ordering of group.by
+    data$grouping <- .keep_levels_if_factor(
+        data$grouping,
+        groupings,
+        groupings.drop.unused)
 
     if (do.hover) {
         data$hover.string <- .make_hover_strings_from_df(data)

--- a/R/dittoPlotVarsAcrossGroups.R
+++ b/R/dittoPlotVarsAcrossGroups.R
@@ -22,6 +22,8 @@
 #' \item{NULL: no adjustment, the normal method for all other ditto expression plotting}
 #' \item{"relative.to.max": divided by the maximum expression value to give percent of max values between [0,1]}
 #' }
+#' @param groupings.drop.unused Logical. \code{TRUE} by default. If \code{group.by}-data is a factor, factor levels are retained for ordering purposes, but some level(s) can end up with zero cells left after \code{cells.use} subsetting.
+#' By default, we remove them, but you can set this input to \code{FALSE} to keep them.
 #' @param do.hover Logical. Default = \code{FALSE}.
 #' If set to \code{TRUE} (and if there is a "jitter" in \code{plots}): the object will be converted to a plotly object in which underlying data about individual points will be displayed when you hover your cursor over them.
 #' @param color.panel String vector which sets the colors to draw from for plot fills.
@@ -163,6 +165,7 @@ dittoPlotVarsAcrossGroups <- function(
     x.labels = NULL,
     x.labels.rotate = NA,
     x.reorder = NULL,
+    groupings.drop.unused = TRUE,
     color.panel = dittoColors(),
     colors = c(seq_along(color.panel)),
     theme = theme_classic(),
@@ -213,7 +216,7 @@ dittoPlotVarsAcrossGroups <- function(
     data <- .data_gather_summarize_vars_by_groups(
         object, vars, group.by, split.by,
         list(summary.fxn), "var.data", cells.use,
-        assay, slot, adjustment, swap.rownames, do.hover)
+        assay, slot, adjustment, swap.rownames, do.hover, groupings.drop.unused)
     
     data$grouping <-
         .rename_and_or_reorder(data$grouping, x.reorder, x.labels)

--- a/R/utils-data-edit.R
+++ b/R/utils-data-edit.R
@@ -52,7 +52,9 @@
     # Turns character vectors into factors
     # Reorders the level of the factor based on indices provided to 'reorder'
     # Re-labels the levels of the factor based on lebels provided to 'relabels'
-    if (is.numeric(orig.data)) {
+    
+    # Need to skip if no reorder or relabels demands because without them, the factor() call at the end will drop unused levels!
+    if (is.numeric(orig.data) || is.null(reorder) && is.null(relabels)) {
         return(orig.data)
     }
     rename.args <- list(x = orig.data)
@@ -69,6 +71,23 @@
         rename.args$labels <- relabels
     }
     do.call(factor, args = rename.args)
+}
+
+.keep_levels_if_factor <- function(current.values, orig.structure, drop.unused = TRUE) {
+    # current.values should be the column as it exists in the to-plot-dataframe
+    # orig.structure should be the original values from the object, already subset by cells.use
+    if (is.factor(orig.structure)) {
+        levs_use <- levels(orig.structure)
+        if (drop.unused) {
+            levs_keep <- unique(as.character(orig.structure))
+            levs_use <- levs_use[levs_use %in% levs_keep]
+        }
+        current.values <- factor(
+            current.values,
+            levels = levs_use
+        )
+    }
+    current.values
 }
 
 .swap_rownames <- function(object, swap.rownames = NULL) {

--- a/man/dittoDotPlot.Rd
+++ b/man/dittoDotPlot.Rd
@@ -36,6 +36,7 @@ dittoDotPlot(
   y.reorder = NULL,
   xlab = NULL,
   x.labels.rotate = TRUE,
+  groupings.drop.unused = TRUE,
   split.nrow = NULL,
   split.ncol = NULL,
   split.adjust = list(),
@@ -118,6 +119,9 @@ is to make the target data into a factor, and to put its levels in the desired o
 Set to \code{NULL} to remove.}
 
 \item{x.labels.rotate}{Logical which sets whether the var-labels should be rotated.}
+
+\item{groupings.drop.unused}{Logical. \code{TRUE} by default. If \code{group.by}-data is a factor, factor levels are retained for ordering purposes, but some level(s) can end up with zero cells left after \code{cells.use} subsetting.
+By default, we remove them, but you can set this input to \code{FALSE} to keep them.}
 
 \item{split.nrow, split.ncol}{Integers which set the dimensions of faceting/splitting when a single metadata is given to \code{split.by}.}
 

--- a/man/dittoPlotVarsAcrossGroups.Rd
+++ b/man/dittoPlotVarsAcrossGroups.Rd
@@ -28,6 +28,7 @@ dittoPlotVarsAcrossGroups(
   x.labels = NULL,
   x.labels.rotate = NA,
   x.reorder = NULL,
+  groupings.drop.unused = TRUE,
   color.panel = dittoColors(),
   colors = c(seq_along(color.panel)),
   theme = theme_classic(),
@@ -137,6 +138,9 @@ Values of x.reorder should be these indices, but in the order that you would lik
 Recommendation for advanced users: If you find yourself coming back to this input too many times, an alternative solution that can be easier long-term
 is to make the target data into a factor, and to put its levels in the desired order: \code{factor(data, levels = c("level1", "level2", ...))}.
 \code{\link{metaLevels}} can be used to quickly get the identities that need to be part of this 'levels' input.}
+
+\item{groupings.drop.unused}{Logical. \code{TRUE} by default. If \code{group.by}-data is a factor, factor levels are retained for ordering purposes, but some level(s) can end up with zero cells left after \code{cells.use} subsetting.
+By default, we remove them, but you can set this input to \code{FALSE} to keep them.}
 
 \item{color.panel}{String vector which sets the colors to draw from for plot fills.}
 

--- a/tests/testthat/test-DotPlot.R
+++ b/tests/testthat/test-DotPlot.R
@@ -238,3 +238,46 @@ test_that("dittoDotPlot split.by works", {
         split2$p,
         "ggplot")
 })
+
+test_that("dittoDotPlot retains group factor levels and optionally drops unused ones", {
+    not_factor <- dittoDotPlot(
+        sce, genes, "groups", data.out = TRUE,
+        split.by = disc2)
+    
+    sce$groups <- factor(sce$groups)
+    with_gE <- dittoDotPlot(
+        sce, genes, "groups", data.out = TRUE,
+        split.by = disc2)
+    without_gE <- dittoDotPlot(
+        sce, genes, "groups", data.out = TRUE,
+        split.by = disc2,
+        cells.use = sce$groups!="E")
+    without_gE_no_drop <- dittoDotPlot(
+        sce, genes, "groups", data.out = TRUE,
+        split.by = disc2,
+        cells.use = sce$groups!="E",
+        groupings.drop.unused = FALSE)
+    
+    # Plots made
+    expect_s3_class(
+        with_gE$p,
+        "ggplot")
+    expect_s3_class(
+        without_gE$p,
+        "ggplot")
+    expect_s3_class(
+        without_gE_no_drop$p,
+        "ggplot")
+    
+    # Factor if originally factor, not if not
+    expect_type(not_factor$data$grouping, "character")
+    expect_type(with_gE$data$grouping, "integer")
+    
+    # Drop is optional
+    expect_equal(
+        levels(with_gE$data$grouping),
+        levels(without_gE_no_drop$data$grouping))
+    expect_true(
+        length(levels(with_gE$data$grouping)) >
+        length(levels(without_gE$data$grouping)))
+})


### PR DESCRIPTION
PR accomplishes exactly as the title states.  Currently, regardless of whether the `group.by` data is a factor or not, the analogous column of the data.frame created and used for plotting is of type character.  This PR adds a check of 'Is the original grouping data a factor?' then, if yes, it turns the analogous column for the plotting data.frame into a factor with the same levels.

Simply that for now, but ToDo before any merge:
- [x] Explore need for deleting unused levels
- [x] Check edge cases
- [x] function-ize this code and extend elsewhere?