### PR TITLE
small bug fix in getReductions()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dittoSeq
 Type: Package
 Title: User Friendly Single-Cell and Bulk RNA Sequencing Visualization
-Version: 1.13.1
+Version: 1.13.2
 Authors@R: c(person("Daniel", "Bunis", email = "daniel.bunis@ucsf.edu", role=c("aut", "cre")),
     person("Jared", "Andrews", email = "jared.andrews07@gmail.com", role=c("aut", "ctb")))
 Description: A universal, user friendly, single-cell and bulk RNA sequencing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dittoSeq 1.13.2
+
+* Bug Fix: 'getReductions()' now correctly returns NULL if the object contains no dimensionality reductions.
+
 # dittoSeq 1.13.1
 
 * Improved group ordering control for 'dittoDotPlot()' and 'dittoPlotVarsAcrossGroups()'. Factor level order of original 'group.by'-data data will now be retained, with added control of whether to unused (empty) levels should be kept via a new 'groupings.drop.unused' input.

--- a/R/get.reductions.R
+++ b/R/get.reductions.R
@@ -18,15 +18,18 @@
 getReductions <- function(object){
 
     if (is(object,"SingleCellExperiment")) {
-        return(SingleCellExperiment::reducedDimNames(object))
+        red <- SingleCellExperiment::reducedDimNames(object)
     }
     if (is(object,"Seurat")) {
         .error_if_no_Seurat()
-        return(Seurat::Reductions(object))
+        red <- Seurat::Reductions(object)
     }
     if (is(object,"seurat")) {
-        return(names(object@dr))
+        red <- names(object@dr)
     }
     
-    NULL
+    red.len <- length(red)
+    red <- if(red.len==0) NULL else red
+    return(red)
+    
 }


### PR DESCRIPTION
Fixes https://support.bioconductor.org/p/9153800/

Bug Fix: `getReductions()` now returns NULL rather than `character(0)` if no dimensionality reductions can be found in `object`, so downstream functions will not choke on the error as in the Bioc issue above.