### PR TITLE
Feature-add / bug fix: allow annot.by = 'ident' in dittoHeatmap for Seurat objects

### DIFF
--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -276,6 +276,9 @@ dittoHeatmap <- function(
         stop("rows of 'annotation_col' must be cell/sample names of all cells/samples being displayed")
     }
     if (!is.null(annot.by)) {
+        if ("ident" %in% annot.by && isMeta("ident", object) && !"ident" %in% getMetas(object)) {
+            object$ident <- meta("ident", object)
+        }
         annotation_col <- rbind(
             as.data.frame(getMetas(object, names.only = FALSE)[cells.use, annot.by, drop = FALSE]),
             annotation_col[cells.use, , drop=FALSE])


### PR DESCRIPTION
Per an emailed support question, users may expect `annot.by = "ident"` to work in `dittoHeatmap()` for Seurat objects, for pulling and annotating by clustering.

This PR adds this feature / fixes this perceived bug.