### PR TITLE
bug-fix: dittoHeatmap shouldn't toss genes with pre-scaled (mean of 0) expression

### DIFF
--- a/R/dittoHeatmap.R
+++ b/R/dittoHeatmap.R
@@ -506,8 +506,8 @@ dittoHeatmap <- function(
         stop("No 'genes' or 'metas' requested") 
     } 
 
-    if (any(rowSums(data)==0)) { 
-        data <- data[rowSums(data)!=0,] 
+    if (any(rowSums(data!=0)==0)) {
+        data <- data[rowSums(data!=0)!=0,]
         if (nrow(data)==0) { 
             stop("No target genes/metadata features have non-zero values in the 'cells.use' subset") 
         } 

--- a/tests/testthat/test-Heatmap.R
+++ b/tests/testthat/test-Heatmap.R
@@ -452,6 +452,22 @@ test_that("dittoHeatmap drops levles from annotation_colors to allow 'drop_level
         "pheatmap")
 })
 
+test_that("dittoHeatmap works for pre-scaled data", {
+    # Generally scale
+    assay(sce, "scaled") <- as.matrix(t(scale(t(round(logcounts(sce), 2)))))
+    # Ensure some zero rowSums (needed due to rounding)
+    assay(sce, "scaled")["gene1",] <- scale(1:ncol(sce), scale = FALSE)
+    # Ensure not all genes so always warning generated, not error
+    assay(sce, "scaled")["gene2",] <- assay(sce, "scaled")["gene2",]+0.05
+
+    expect_warning(
+        h <- dittoHeatmap(genes = genes, object = sce,
+                     assay = "scaled", scale = "none",
+                     drop_levels = TRUE),
+        NA)
+    expect_s3_class(h, "pheatmap")
+})
+
 ### Seurat test
 test_that("dittoHeatmap allows annotation by 'ident' as would be expected", {
     # errors if not Seurat


### PR DESCRIPTION
Literal fix: actually check for non-zero values, instead of just a non-zero sum, when removing genes with zero expression.

Per #127

ToDo:
- [x] unit test
- [ ] understand Seurat's DoHeatmap methodology better so can more confidently describe how to recreate their plotting style.