### PR TITLE
Additional data representation controls for dittoPlot and related plotters

### DIFF
--- a/R/dittoFreqPlot.R
+++ b/R/dittoFreqPlot.R
@@ -205,6 +205,7 @@ dittoFreqPlot <- function(
     vlnplot.lineweight = 1,
     vlnplot.width = 1,
     vlnplot.scaling = "area",
+    vlnplot.quantiles = NULL,
     ridgeplot.lineweight = 1,
     ridgeplot.scale = 1.25,
     ridgeplot.ymax.expansion = NA,
@@ -288,8 +289,9 @@ dittoFreqPlot <- function(
             boxplot.width, boxplot.color, boxplot.show.outliers,
             boxplot.outlier.size, boxplot.fill,
             boxplot.position.dodge, boxplot.lineweight, vlnplot.lineweight,
-            vlnplot.width, vlnplot.scaling, add.line, line.linetype,
-            line.color, x.labels.rotate, do.hover, y.breaks, min, max, object)
+            vlnplot.width, vlnplot.scaling, vlnplot.quantiles,
+            add.line, line.linetype, line.color,
+            x.labels.rotate, do.hover, y.breaks, min, max, object)
     } else {
         p <- .dittoPlot_add_data_x_direction(
             p, data, plots, xlab, ylab, jitter.size, jitter.color, NA, TRUE,

--- a/R/dittoFreqPlot.R
+++ b/R/dittoFreqPlot.R
@@ -198,6 +198,7 @@ dittoFreqPlot <- function(
     boxplot.width = 0.4,
     boxplot.color = "black",
     boxplot.show.outliers = NA,
+    boxplot.outlier.size = 1.5,
     boxplot.fill = TRUE,
     boxplot.position.dodge = vlnplot.width,
     boxplot.lineweight = 1,
@@ -284,7 +285,8 @@ dittoFreqPlot <- function(
             p, data, plots, xlab, ylab, NULL, jitter.size, jitter.width,
             jitter.color, 16, NA, TRUE, jitter.position.dodge,
             do.raster, raster.dpi,
-            boxplot.width, boxplot.color, boxplot.show.outliers, boxplot.fill,
+            boxplot.width, boxplot.color, boxplot.show.outliers,
+            boxplot.outlier.size, boxplot.fill,
             boxplot.position.dodge, boxplot.lineweight, vlnplot.lineweight,
             vlnplot.width, vlnplot.scaling, add.line, line.linetype,
             line.color, x.labels.rotate, do.hover, y.breaks, min, max, object)

--- a/R/dittoPlot.R
+++ b/R/dittoPlot.R
@@ -112,7 +112,7 @@
 #' @param vlnplot.scaling String which sets how the widths of the of violin plots are set in relation to each other.
 #' Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
 #' For an explanation of each, see \code{\link{geom_violin}}.
-#' @param vlnplot.quantiles Numeric vector naming quantiles at which to draw a line in each violin plot.
+#' @param vlnplot.quantiles Single number or numeric vector of values in [0,1] naming quantiles at which to draw a horizontal line within each violin plot. Example: \code{c(0.1, 0.5, 0.9)}
 #' @param ridgeplot.lineweight Scalar which sets the thickness of the ridgeplot outline.
 #' @param ridgeplot.scale Scalar which sets the distance/overlap between ridgeplots.
 #' A value of 1 means the tallest density curve just touches the baseline of the next higher one.

--- a/R/dittoPlot.R
+++ b/R/dittoPlot.R
@@ -112,6 +112,7 @@
 #' @param vlnplot.scaling String which sets how the widths of the of violin plots are set in relation to each other.
 #' Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
 #' For an explanation of each, see \code{\link{geom_violin}}.
+#' @param vlnplot.quantiles Numeric vector naming quantiles at which to draw a line in each violin plot.
 #' @param ridgeplot.lineweight Scalar which sets the thickness of the ridgeplot outline.
 #' @param ridgeplot.scale Scalar which sets the distance/overlap between ridgeplots.
 #' A value of 1 means the tallest density curve just touches the baseline of the next higher one.
@@ -305,6 +306,7 @@ dittoPlot <- function(
     vlnplot.lineweight = 1,
     vlnplot.width = 1,
     vlnplot.scaling = "area",
+    vlnplot.quantiles = NULL,
     ridgeplot.lineweight = 1,
     ridgeplot.scale = 1.25,
     ridgeplot.ymax.expansion = NA,
@@ -366,6 +368,7 @@ dittoPlot <- function(
             boxplot.outlier.size, boxplot.fill,
             boxplot.position.dodge, boxplot.lineweight,
             vlnplot.lineweight, vlnplot.width, vlnplot.scaling,
+            vlnplot.quantiles,
             add.line, line.linetype, line.color,
             x.labels.rotate, do.hover, y.breaks, min, max, object)
     } else {
@@ -420,8 +423,9 @@ dittoBoxPlot <- function(..., plots = c("boxplot","jitter")){ dittoPlot(..., plo
     do.raster, raster.dpi,
     boxplot.width, boxplot.color, boxplot.show.outliers, boxplot.outlier.size,
     boxplot.fill, boxplot.position.dodge, boxplot.lineweight,
-    vlnplot.lineweight, vlnplot.width, vlnplot.scaling, add.line,
-    line.linetype, line.color, x.labels.rotate, do.hover, y.breaks, min, max,
+    vlnplot.lineweight, vlnplot.width, vlnplot.scaling, vlnplot.quantiles,
+    add.line, line.linetype, line.color,
+    x.labels.rotate, do.hover, y.breaks, min, max,
     object) {
     # This function takes in a partial dittoPlot ggplot object without any data
     # overlay, and parses adding the main data visualizations.
@@ -444,6 +448,7 @@ dittoBoxPlot <- function(..., plots = c("boxplot","jitter")){ dittoPlot(..., plo
                 size = vlnplot.lineweight,
                 width = vlnplot.width,
                 scale = vlnplot.scaling,
+                draw_quantiles = vlnplot.quantiles,
                 na.rm = TRUE)
         }
 

--- a/R/dittoPlot.R
+++ b/R/dittoPlot.R
@@ -101,6 +101,7 @@
 #' @param boxplot.color String which sets the color of the lines of the boxplot
 #' @param boxplot.show.outliers Logical, whether outliers should by including in the boxplot.
 #' Default is \code{FALSE} when there is a jitter plotted, \code{TRUE} if there is no jitter.
+#' @param boxplot.outlier.size Scalar which adjusts the size of points used to mark outliers
 #' @param boxplot.fill Logical, whether the boxplot should be filled in or not.
 #' Known bug: when boxplot fill is turned off, outliers do not render.
 #' @param boxplot.position.dodge Scalar which adjusts the relative distance between boxplots when multiple are drawn per grouping (a.k.a. when \code{group.by} and \code{color.by} are not equal).
@@ -297,6 +298,7 @@ dittoPlot <- function(
     boxplot.width = 0.2,
     boxplot.color = "black",
     boxplot.show.outliers = NA,
+    boxplot.outlier.size = 1.5,
     boxplot.fill = TRUE,
     boxplot.position.dodge = vlnplot.width,
     boxplot.lineweight = 1,
@@ -360,7 +362,8 @@ dittoPlot <- function(
             jitter.width, jitter.color, shape.panel, jitter.shape.legend.size,
             jitter.shape.legend.show, jitter.position.dodge,
             do.raster, raster.dpi,
-            boxplot.width, boxplot.color, boxplot.show.outliers, boxplot.fill,
+            boxplot.width, boxplot.color, boxplot.show.outliers,
+            boxplot.outlier.size, boxplot.fill,
             boxplot.position.dodge, boxplot.lineweight,
             vlnplot.lineweight, vlnplot.width, vlnplot.scaling,
             add.line, line.linetype, line.color,
@@ -415,8 +418,8 @@ dittoBoxPlot <- function(..., plots = c("boxplot","jitter")){ dittoPlot(..., plo
     jitter.size, jitter.width, jitter.color,shape.panel,
     jitter.shape.legend.size, jitter.shape.legend.show, jitter.position.dodge,
     do.raster, raster.dpi,
-    boxplot.width, boxplot.color, boxplot.show.outliers, boxplot.fill,
-    boxplot.position.dodge, boxplot.lineweight,
+    boxplot.width, boxplot.color, boxplot.show.outliers, boxplot.outlier.size,
+    boxplot.fill, boxplot.position.dodge, boxplot.lineweight,
     vlnplot.lineweight, vlnplot.width, vlnplot.scaling, add.line,
     line.linetype, line.color, x.labels.rotate, do.hover, y.breaks, min, max,
     object) {
@@ -451,6 +454,7 @@ dittoBoxPlot <- function(..., plots = c("boxplot","jitter")){ dittoPlot(..., plo
                 lwd = boxplot.lineweight,
                 alpha = ifelse(boxplot.fill, 1, 0),
                 position = position_dodge(width = boxplot.position.dodge),
+                outlier.size = boxplot.outlier.size,
                 na.rm = TRUE)
             if (is.na(boxplot.show.outliers)) {
                 boxplot.show.outliers <- ifelse("jitter" %in% plots, FALSE, TRUE)

--- a/R/dittoPlotVarsAcrossGroups.R
+++ b/R/dittoPlotVarsAcrossGroups.R
@@ -178,6 +178,7 @@ dittoPlotVarsAcrossGroups <- function(
     boxplot.width = 0.2,
     boxplot.color = "black",
     boxplot.show.outliers = NA,
+    boxplot.outlier.size = 1.5,
     boxplot.fill = TRUE,
     boxplot.position.dodge = vlnplot.width,
     boxplot.lineweight = 1,
@@ -243,7 +244,8 @@ dittoPlotVarsAcrossGroups <- function(
         p <- .dittoPlot_add_data_y_direction(
             p, data, plots, xlab, ylab, NULL, jitter.size, jitter.width,
             jitter.color, 16, NA, TRUE, jitter.position.dodge, do.raster, raster.dpi,
-            boxplot.width, boxplot.color, boxplot.show.outliers, boxplot.fill,
+            boxplot.width, boxplot.color, boxplot.show.outliers,
+            boxplot.outlier.size, boxplot.fill,
             boxplot.position.dodge, boxplot.lineweight, vlnplot.lineweight,
             vlnplot.width, vlnplot.scaling, add.line, line.linetype,
             line.color, x.labels.rotate, do.hover, y.breaks, min, max, object)

--- a/R/dittoPlotVarsAcrossGroups.R
+++ b/R/dittoPlotVarsAcrossGroups.R
@@ -185,6 +185,7 @@ dittoPlotVarsAcrossGroups <- function(
     vlnplot.lineweight = 1,
     vlnplot.width = 1,
     vlnplot.scaling = "area",
+    vlnplot.quantiles = NULL,
     ridgeplot.lineweight = 1,
     ridgeplot.scale = 1.25,
     ridgeplot.ymax.expansion = NA,
@@ -247,8 +248,9 @@ dittoPlotVarsAcrossGroups <- function(
             boxplot.width, boxplot.color, boxplot.show.outliers,
             boxplot.outlier.size, boxplot.fill,
             boxplot.position.dodge, boxplot.lineweight, vlnplot.lineweight,
-            vlnplot.width, vlnplot.scaling, add.line, line.linetype,
-            line.color, x.labels.rotate, do.hover, y.breaks, min, max, object)
+            vlnplot.width, vlnplot.scaling, vlnplot.quantiles,
+            add.line, line.linetype, line.color,
+            x.labels.rotate, do.hover, y.breaks, min, max, object)
     } else {
         p <- .dittoPlot_add_data_x_direction(
             p, data, plots, xlab, ylab, jitter.size, jitter.color,

--- a/man/dittoFreqPlot.Rd
+++ b/man/dittoFreqPlot.Rd
@@ -44,6 +44,7 @@ dittoFreqPlot(
   boxplot.width = 0.4,
   boxplot.color = "black",
   boxplot.show.outliers = NA,
+  boxplot.outlier.size = 1.5,
   boxplot.fill = TRUE,
   boxplot.position.dodge = vlnplot.width,
   boxplot.lineweight = 1,
@@ -188,6 +189,8 @@ This can be useful for editing in external programs (e.g. Illustrator) when ther
 
 \item{boxplot.show.outliers}{Logical, whether outliers should by including in the boxplot.
 Default is \code{FALSE} when there is a jitter plotted, \code{TRUE} if there is no jitter.}
+
+\item{boxplot.outlier.size}{Scalar which adjusts the size of points used to mark outliers}
 
 \item{boxplot.fill}{Logical, whether the boxplot should be filled in or not.
 Known bug: when boxplot fill is turned off, outliers do not render.}

--- a/man/dittoFreqPlot.Rd
+++ b/man/dittoFreqPlot.Rd
@@ -51,6 +51,7 @@ dittoFreqPlot(
   vlnplot.lineweight = 1,
   vlnplot.width = 1,
   vlnplot.scaling = "area",
+  vlnplot.quantiles = NULL,
   ridgeplot.lineweight = 1,
   ridgeplot.scale = 1.25,
   ridgeplot.ymax.expansion = NA,
@@ -207,6 +208,8 @@ By default, this input actually controls the value of \code{jitter.position.dodg
 \item{vlnplot.scaling}{String which sets how the widths of the of violin plots are set in relation to each other.
 Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
 For an explanation of each, see \code{\link{geom_violin}}.}
+
+\item{vlnplot.quantiles}{Numeric vector naming quantiles at which to draw a line in each violin plot.}
 
 \item{ridgeplot.lineweight}{Scalar which sets the thickness of the ridgeplot outline.}
 

--- a/man/dittoFreqPlot.Rd
+++ b/man/dittoFreqPlot.Rd
@@ -209,7 +209,7 @@ By default, this input actually controls the value of \code{jitter.position.dodg
 Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
 For an explanation of each, see \code{\link{geom_violin}}.}
 
-\item{vlnplot.quantiles}{Numeric vector naming quantiles at which to draw a line in each violin plot.}
+\item{vlnplot.quantiles}{Single number or numeric vector of values in [0,1] naming quantiles at which to draw a horizontal line within each violin plot. Example: \code{c(0.1, 0.5, 0.9)}}
 
 \item{ridgeplot.lineweight}{Scalar which sets the thickness of the ridgeplot outline.}
 

--- a/man/dittoPlot.Rd
+++ b/man/dittoPlot.Rd
@@ -60,6 +60,7 @@ dittoPlot(
   vlnplot.lineweight = 1,
   vlnplot.width = 1,
   vlnplot.scaling = "area",
+  vlnplot.quantiles = NULL,
   ridgeplot.lineweight = 1,
   ridgeplot.scale = 1.25,
   ridgeplot.ymax.expansion = NA,
@@ -234,6 +235,8 @@ By default, this input actually controls the value of \code{jitter.position.dodg
 \item{vlnplot.scaling}{String which sets how the widths of the of violin plots are set in relation to each other.
 Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
 For an explanation of each, see \code{\link{geom_violin}}.}
+
+\item{vlnplot.quantiles}{Numeric vector naming quantiles at which to draw a line in each violin plot.}
 
 \item{ridgeplot.lineweight}{Scalar which sets the thickness of the ridgeplot outline.}
 

--- a/man/dittoPlot.Rd
+++ b/man/dittoPlot.Rd
@@ -53,6 +53,7 @@ dittoPlot(
   boxplot.width = 0.2,
   boxplot.color = "black",
   boxplot.show.outliers = NA,
+  boxplot.outlier.size = 1.5,
   boxplot.fill = TRUE,
   boxplot.position.dodge = vlnplot.width,
   boxplot.lineweight = 1,
@@ -215,6 +216,8 @@ Similar to \code{boxplot.position.dodge} input & defaults to the value of that i
 
 \item{boxplot.show.outliers}{Logical, whether outliers should by including in the boxplot.
 Default is \code{FALSE} when there is a jitter plotted, \code{TRUE} if there is no jitter.}
+
+\item{boxplot.outlier.size}{Scalar which adjusts the size of points used to mark outliers}
 
 \item{boxplot.fill}{Logical, whether the boxplot should be filled in or not.
 Known bug: when boxplot fill is turned off, outliers do not render.}

--- a/man/dittoPlot.Rd
+++ b/man/dittoPlot.Rd
@@ -236,7 +236,7 @@ By default, this input actually controls the value of \code{jitter.position.dodg
 Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
 For an explanation of each, see \code{\link{geom_violin}}.}
 
-\item{vlnplot.quantiles}{Numeric vector naming quantiles at which to draw a line in each violin plot.}
+\item{vlnplot.quantiles}{Single number or numeric vector of values in [0,1] naming quantiles at which to draw a horizontal line within each violin plot. Example: \code{c(0.1, 0.5, 0.9)}}
 
 \item{ridgeplot.lineweight}{Scalar which sets the thickness of the ridgeplot outline.}
 

--- a/man/dittoPlotVarsAcrossGroups.Rd
+++ b/man/dittoPlotVarsAcrossGroups.Rd
@@ -48,6 +48,7 @@ dittoPlotVarsAcrossGroups(
   vlnplot.lineweight = 1,
   vlnplot.width = 1,
   vlnplot.scaling = "area",
+  vlnplot.quantiles = NULL,
   ridgeplot.lineweight = 1,
   ridgeplot.scale = 1.25,
   ridgeplot.ymax.expansion = NA,
@@ -193,6 +194,8 @@ By default, this input actually controls the value of \code{jitter.position.dodg
 \item{vlnplot.scaling}{String which sets how the widths of the of violin plots are set in relation to each other.
 Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
 For an explanation of each, see \code{\link{geom_violin}}.}
+
+\item{vlnplot.quantiles}{Numeric vector naming quantiles at which to draw a line in each violin plot.}
 
 \item{ridgeplot.lineweight}{Scalar which sets the thickness of the ridgeplot outline.}
 

--- a/man/dittoPlotVarsAcrossGroups.Rd
+++ b/man/dittoPlotVarsAcrossGroups.Rd
@@ -195,7 +195,7 @@ By default, this input actually controls the value of \code{jitter.position.dodg
 Options are "area", "count", and "width". If the default is not right for your data, I recommend trying "width".
 For an explanation of each, see \code{\link{geom_violin}}.}
 
-\item{vlnplot.quantiles}{Numeric vector naming quantiles at which to draw a line in each violin plot.}
+\item{vlnplot.quantiles}{Single number or numeric vector of values in [0,1] naming quantiles at which to draw a horizontal line within each violin plot. Example: \code{c(0.1, 0.5, 0.9)}}
 
 \item{ridgeplot.lineweight}{Scalar which sets the thickness of the ridgeplot outline.}
 

--- a/man/dittoPlotVarsAcrossGroups.Rd
+++ b/man/dittoPlotVarsAcrossGroups.Rd
@@ -41,6 +41,7 @@ dittoPlotVarsAcrossGroups(
   boxplot.width = 0.2,
   boxplot.color = "black",
   boxplot.show.outliers = NA,
+  boxplot.outlier.size = 1.5,
   boxplot.fill = TRUE,
   boxplot.position.dodge = vlnplot.width,
   boxplot.lineweight = 1,
@@ -174,6 +175,8 @@ This can be useful for editing in external programs (e.g. Illustrator) when ther
 
 \item{boxplot.show.outliers}{Logical, whether outliers should by including in the boxplot.
 Default is \code{FALSE} when there is a jitter plotted, \code{TRUE} if there is no jitter.}
+
+\item{boxplot.outlier.size}{Scalar which adjusts the size of points used to mark outliers}
 
 \item{boxplot.fill}{Logical, whether the boxplot should be filled in or not.
 Known bug: when boxplot fill is turned off, outliers do not render.}

--- a/tests/testthat/test-Plot.R
+++ b/tests/testthat/test-Plot.R
@@ -314,20 +314,22 @@ test_that("dittoPlot jitter adjustments work", {
 
 test_that("dittoPlot boxplot adjustments work", {
     # Manuel Check: Blue boxplots that touch eachother, with jitter visible behind.
-    # Not actually checked here manually: whether outliers are shown cuz there are none.
     expect_s3_class(
         dittoPlot(
             "number", object=sce, group.by = grp, plots = c("jitter", "boxplot"),
-            boxplot.width = 1, boxplot.color = "blue", boxplot.fill = FALSE,
-            boxplot.show.outliers = TRUE),
+            boxplot.width = 1, boxplot.color = "blue", boxplot.fill = FALSE),
         "ggplot")
     # Manual Check: boxplots that overlap, with thick lines
+    sce$number[75]<- 100
     expect_s3_class(
         dittoPlot(
             "number", object=sce, group.by = grp, plots = c("jitter","boxplot"),
             color.by = clr,
             boxplot.width = 0.4, boxplot.position.dodge = 0.2,
-            boxplot.lineweight = 2),
+            boxplot.lineweight = 2,
+            boxplot.outlier.size = 15,
+            boxplot.show.outliers = TRUE
+            ),
         "ggplot")
 })
 
@@ -353,6 +355,11 @@ test_that("dittoPlot violin plot adjustments work", {
         dittoPlot(
             "number", object=sce, group.by = grp,
             vlnplot.scaling = "width"),
+        "ggplot")
+    expect_s3_class(
+        dittoPlot(
+            "number", object=sce, group.by = grp,
+            vlnplot.quantiles = c(0.25, 0.5, 0.75)),
         "ggplot")
 })
 


### PR DESCRIPTION
Adds additional control to how data representations requested via the`plots` inputs can be shown.  Specifically:
- `boxplot.outlier.size` (passed to `geom_boxplot(outlier.size)`), per #133 
- `vlnplot.quantiles` (passed to `geom_violin(draw_quantiles)`)

ToDo before merge:
- [x] double-check documentation
- [x] add unit tests