### PR TITLE
add 'labels.repel.adjust' input to all scatter-type plotters

### DIFF
--- a/R/DittoDimPlot.R
+++ b/R/DittoDimPlot.R
@@ -94,6 +94,8 @@
 #' TRUE by default.
 #' @param labels.split.by String of one or two metadata names which controls the facet-split calculations for label placements.
 #' Defaults to \code{split.by}, so generally there is no need to adjust this except when you are utilizing the \code{extra.vars} input to achieve manual faceting control.
+#' @param labels.repel.adjust A named list which allows extra parameters to be pushed through to ggrepel function calls.
+#' List elements should be valid inputs to the \code{\link[ggrepel]{geom_label_repel}} by default, or \code{\link[ggrepel]{geom_text_repel}} when \code{labels.highlight = FALSE}.
 #' @param rename.var.groups String vector which sets new names for the identities of \code{var} groups.
 #' @param rename.shape.groups String vector which sets new names for the identities of \code{shape.by} groups.
 #' @param min.color color for lowest values of \code{var}/\code{min}.  Default = yellow
@@ -312,6 +314,7 @@ dittoDimPlot <- function(
     labels.highlight = TRUE,
     labels.repel = TRUE,
     labels.split.by = split.by,
+    labels.repel.adjust = list(),
     do.hover = FALSE,
     hover.data = var,
     hover.assay = .default_assay(object),
@@ -377,7 +380,7 @@ dittoDimPlot <- function(
         add.trajectory.lineages, add.trajectory.curves = NULL,
         trajectory.cluster.meta, trajectory.arrow.size,
         do.letter, do.ellipse, do.label, labels.size, labels.highlight,
-        labels.repel, labels.split.by,
+        labels.repel, labels.split.by, labels.repel.adjust,
         legend.show, legend.title, legend.size,
         legend.breaks, legend.breaks.labels, shape.legend.title,
         shape.legend.size, do.raster, raster.dpi, data.out = TRUE)

--- a/R/DittoScatterPlot.R
+++ b/R/DittoScatterPlot.R
@@ -244,6 +244,7 @@ dittoScatterPlot <- function(
     labels.highlight = TRUE,
     labels.repel = TRUE,
     labels.split.by = split.by,
+    labels.repel.adjust = list(),
     legend.show = TRUE,
     legend.color.title = "make",
     legend.color.size = 5,
@@ -318,6 +319,7 @@ dittoScatterPlot <- function(
         p, Target_data, is.discrete = !is.numeric(Target_data$color),
         do.letter, do.ellipse, do.label,
         labels.highlight, labels.size, labels.repel, labels.split.by,
+        labels.repel.adjust,
         size, opacity, legend.color.title, legend.color.size)
     
     if (is.list(add.trajectory.lineages)) {

--- a/R/dittoHex.R
+++ b/R/dittoHex.R
@@ -206,6 +206,7 @@ dittoDimHex <- function(
     labels.highlight = TRUE,
     labels.repel = TRUE,
     labels.split.by = split.by,
+    labels.repel.adjust = list(),
     add.trajectory.lineages = NULL,
     add.trajectory.curves = NULL,
     trajectory.cluster.meta,
@@ -252,7 +253,7 @@ dittoDimHex <- function(
         rename.color.groups, xlab, ylab, main, sub, theme,
         do.contour, contour.color, contour.linetype,
         do.ellipse, do.label, labels.size, labels.highlight, labels.repel,
-        labels.split.by,
+        labels.split.by, labels.repel.adjust,
         add.trajectory.lineages, add.trajectory.curves = NULL,
         trajectory.cluster.meta, trajectory.arrow.size,
         legend.show,
@@ -332,6 +333,7 @@ dittoScatterHex <- function(
     labels.highlight = TRUE,
     labels.repel = TRUE,
     labels.split.by = split.by,
+    labels.repel.adjust = list(),
     add.trajectory.lineages = NULL,
     add.trajectory.curves = NULL,
     trajectory.cluster.meta,
@@ -423,7 +425,8 @@ dittoScatterHex <- function(
     p <- .add_letters_ellipses_labels_if_discrete(
         p, data, is.discrete = discrete_data,
         FALSE, do.ellipse, do.label,
-        labels.highlight, labels.size, labels.repel, labels.split.by)
+        labels.highlight, labels.size, labels.repel, labels.split.by,
+        labels.repel.adjust)
     
     if (is.list(add.trajectory.lineages)) {
         p <- .add_trajectory_lineages(

--- a/R/utils-plot-mods.R
+++ b/R/utils-plot-mods.R
@@ -34,6 +34,7 @@
     p, data,
     is.discrete, do.letter, do.ellipse, do.label,
     labels.highlight, labels.size, labels.repel, labels.split.by,
+    labels.repel.adjust,
     letter.size, letter.opacity, letter.legend.title, letter.legend.size,
     column = "color") {
     
@@ -55,7 +56,7 @@
         if (do.label) {
             p <- .add_labels(
                 p, data, column, labels.highlight, labels.size,
-                labels.repel, labels.split.by)
+                labels.repel, labels.repel.adjust, labels.split.by)
         }
         
     } else {
@@ -87,7 +88,8 @@
 
 .add_labels <- function(
     p, Target_data, col.use = "color",
-    labels.highlight, labels.size, labels.repel, split.by) {
+    labels.highlight, labels.size, labels.repel, labels.repel.adjust,
+    split.by) {
     # Add text labels at/near the median x and y values for each group
     # (Dim and Scatter plots)
 
@@ -103,7 +105,6 @@
         for (level in levels(as.factor(as.character(Target_data[,split.by])))) {
             
             level.dat <- Target_data[Target_data[,split.by]==level,]
-                
             level.med.dat <- .calc_center_medians(level.dat, col.use)
             # Add split.by columns
             level.med.dat$split1 <- level
@@ -122,10 +123,10 @@
         
         for (level1 in levels(as.factor(as.character(Target_data[,split.by[1]])))) {
             for (level2 in levels(as.factor(as.character(Target_data[,split.by[2]])))) {
-            
+
                 level.dat <- Target_data[Target_data[,split.by[1]]==level1,]
                 level.dat <- level.dat[level.dat[,split.by[2]]==level2,]
-                    
+
                 if (nrow(level.dat)>0) {
                     level.med.dat <- .calc_center_medians(level.dat, col.use)
                     # Add split.by columns
@@ -150,20 +151,23 @@
         data = median.data,
         mapping = aes_string(x = "cent.x", y = "cent.y", label = "label"),
         size = labels.size)
-    geom.use <-
-        if (labels.highlight) {
-            if (labels.repel) {
-                ggrepel::geom_label_repel
-            } else {
-                geom_label
-            }
-        } else {
-            if (labels.repel) {
-                ggrepel::geom_text_repel
-            } else {
-                geom_text
-            }
+    if (labels.repel) {
+        if (is.list(labels.repel.adjust)) {
+            args <- c(args, labels.repel.adjust)
         }
+        geom.use <- if (labels.highlight) {
+            ggrepel::geom_label_repel
+        } else {
+            ggrepel::geom_text_repel
+        }
+    } else {
+        geom.use <- if (labels.highlight) {
+            geom_label
+        } else {
+            geom_text
+        }
+    }
+
     p + do.call(geom.use, args)
 }
 

--- a/man/dittoDimPlot.Rd
+++ b/man/dittoDimPlot.Rd
@@ -55,6 +55,7 @@ dittoDimPlot(
   labels.highlight = TRUE,
   labels.repel = TRUE,
   labels.split.by = split.by,
+  labels.repel.adjust = list(),
   do.hover = FALSE,
   hover.data = var,
   hover.assay = .default_assay(object),
@@ -218,6 +219,9 @@ TRUE by default.}
 
 \item{labels.split.by}{String of one or two metadata names which controls the facet-split calculations for label placements.
 Defaults to \code{split.by}, so generally there is no need to adjust this except when you are utilizing the \code{extra.vars} input to achieve manual faceting control.}
+
+\item{labels.repel.adjust}{A named list which allows extra parameters to be pushed through to ggrepel function calls.
+List elements should be valid inputs to the \code{\link[ggrepel]{geom_label_repel}} by default, or \code{\link[ggrepel]{geom_text_repel}} when \code{labels.highlight = FALSE}.}
 
 \item{do.hover}{Logical which controls whether the output will be converted to a plotly object so that data about individual points will be displayed when you hover your cursor over them.
 \code{hover.data} argument is used to determine what data to use.}

--- a/man/dittoHex.Rd
+++ b/man/dittoHex.Rd
@@ -55,6 +55,7 @@ dittoDimHex(
   labels.highlight = TRUE,
   labels.repel = TRUE,
   labels.split.by = split.by,
+  labels.repel.adjust = list(),
   add.trajectory.lineages = NULL,
   add.trajectory.curves = NULL,
   trajectory.cluster.meta,
@@ -121,6 +122,7 @@ dittoScatterHex(
   labels.highlight = TRUE,
   labels.repel = TRUE,
   labels.split.by = split.by,
+  labels.repel.adjust = list(),
   add.trajectory.lineages = NULL,
   add.trajectory.curves = NULL,
   trajectory.cluster.meta,
@@ -255,6 +257,9 @@ TRUE by default.}
 
 \item{labels.split.by}{String of one or two metadata names which controls the facet-split calculations for label placements.
 Defaults to \code{split.by}, so generally there is no need to adjust this except when you are utilizing the \code{extra.vars} input to achieve manual faceting control.}
+
+\item{labels.repel.adjust}{A named list which allows extra parameters to be pushed through to ggrepel function calls.
+List elements should be valid inputs to the \code{\link[ggrepel]{geom_label_repel}} by default, or \code{\link[ggrepel]{geom_text_repel}} when \code{labels.highlight = FALSE}.}
 
 \item{add.trajectory.lineages}{List of vectors representing trajectory paths, each from start-cluster to end-cluster, where vector contents are the names of clusters provided in the \code{trajectory.cluster.meta} input.
 

--- a/man/dittoScatterPlot.Rd
+++ b/man/dittoScatterPlot.Rd
@@ -68,6 +68,7 @@ dittoScatterPlot(
   labels.highlight = TRUE,
   labels.repel = TRUE,
   labels.split.by = split.by,
+  labels.repel.adjust = list(),
   legend.show = TRUE,
   legend.color.title = "make",
   legend.color.size = 5,
@@ -222,6 +223,9 @@ TRUE by default.}
 
 \item{labels.split.by}{String of one or two metadata names which controls the facet-split calculations for label placements.
 Defaults to \code{split.by}, so generally there is no need to adjust this except when you are utilizing the \code{extra.vars} input to achieve manual faceting control.}
+
+\item{labels.repel.adjust}{A named list which allows extra parameters to be pushed through to ggrepel function calls.
+List elements should be valid inputs to the \code{\link[ggrepel]{geom_label_repel}} by default, or \code{\link[ggrepel]{geom_text_repel}} when \code{labels.highlight = FALSE}.}
 
 \item{legend.show}{Logical. Whether any legend should be displayed. Default = \code{TRUE}.}
 

--- a/tests/testthat/test-DimPlot.R
+++ b/tests/testthat/test-DimPlot.R
@@ -261,6 +261,21 @@ test_that("dittoDimPlot can be labeled or circled", {
             do.label = TRUE,
             labels.size = 3),
         "ggplot")
+
+    ### Manual Check: all labels to right side
+    expect_s3_class(
+        dittoDimPlot(
+            disc, object=sce,
+            do.label = TRUE,
+            labels.repel.adjust = list(xlim=c(5,NA))),
+        "ggplot")
+    expect_s3_class(
+        dittoDimPlot(
+            disc, object=sce,
+            do.label = TRUE,
+            labels.repel.adjust = list(xlim=c(5,NA)),
+            labels.highlight = FALSE),
+        "ggplot")
 })
 
 test_that("dittoDimPlot labeling is robust to NAs", {


### PR DESCRIPTION
Added 'labels.repel.adjust' input to 'dittoDimPlot()', 'dittoScatterPlot()', 'dittoDimHex()', and 'dittoScatterHex()'. The input allows extra control of how labels will be placed when 'do.label = TRUE' (and 'labels.repel' is not set to FALSE) by providing a mechanism to pass desired parameters through to the ggrepel function used for plotting the labels.

- [x] documentation
- [x] tests in dittoDimPlot