### PR TITLE
Add built-in mechanism for 'dittoDotPlot()' to have a 3-color scale

### DIFF
--- a/R/dittoDotPlot.R
+++ b/R/dittoDotPlot.R
@@ -33,20 +33,21 @@
 #' When set to NA, the minimum/maximum of the data are used.
 #' @param min.color,max.color colors to use for minimum and maximum color values.
 #' Default = light grey and purple.
-#' Ignored if \code{mid.color} given as \code{"rwb"} or \code{"rgb"} which will update these to be "blue" and "red", respectively.
+#' Ignored if \code{mid.color} given as \code{"ryb"}, \code{"rwb"}, or \code{"rgb"} which will update these to be "blue" and "red", respectively.
 #' @param min,max Numbers which set the values associated with the minimum and maximum colors.
-#' @param mid.color NULL (default), "rwb", "rgb", or a color to use for the midpoint of a three-color color scale.
+#' @param mid.color NULL (default), "ryb", "rwb", "rgb", or a color to use for the midpoint of a three-color color scale.
 #' \emph{This parameter acts a switch between using a 2-color scale or a 3-color scale}:\itemize{
 #' \item When left NULL, the 2-color scale runs from \code{min.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient}}.
 #' \item When given a color, the 3-color scale runs from \code{min.color} to \code{mid.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient2}}.
 #' \item{
-#' When given \emph{\code{"rwb"} or \code{"rgb"} serves as a \strong{single-point, quick switch to a "standard" 3-color scale}} by also updating the \code{min.color} and \code{max.color} used:
+#' When given \emph{\code{"ryb"}, \code{"rwb"}, or \code{"rgb"} serves as a \strong{single-point, quick switch to a "standard" 3-color scale}} by also updating the \code{min.color} and \code{max.color}.
 #' Doing so sets:\itemize{
-#'     \item "red" as the \code{max.color},
-#'     \item "blue" as the \code{min.color},
-#'     \item and either "white" ("r\emph{w}b") or "gray90" ("r\emph{g}b") for \code{mid.color}.
+#'     \item \code{max.color} to a red,
+#'     \item \code{min.color} to a blue,
+#'     \item and \code{mid.color} to either a yellow ("r\emph{y}b"), "white" ("r\emph{w}b"), or "gray97" ("r\emph{g}b", gray not green).
+#'     \item Actual colors used are inspired by \href{http://www.colorbrewer.org}{ColorBrewer} "RdYlBu" and "RdBu" palettes.
 #' }
-#' Thus, the 3-color scale runs from "blue" to either "white" or "gray90" to "red", using \code{\link[ggplot2]{scale_fill_gradient2}}.
+#' Thus, the 3-color scale runs from a blue to one of a yellow, "white", or "gray97" to a red, using \code{\link[ggplot2]{scale_fill_gradient2}}.
 #' }
 #' }
 #' @param mid Number or "make" (default) which sets the value associated with the \code{mid.color} of the three-color scale.
@@ -200,15 +201,16 @@
 #' dittoDotPlot(myRNA, c("gene1", "gene2", "gene3", "gene4"), "clustering",
 #'     mid.color = "white"
 #' )
-#' # Setting it to "rgb" or "rwb" quickly updates 'min.color' and 'max.color' too,
-#' #   making the affect of these next two calls equivalent:
+#' # Setting it to "ryb", "rgb", or "rwb" quickly updates this input as well as
+#' #   'min.color' and 'max.color', making the affect of these next two calls
+#' #   equivalent:
 #' dittoDotPlot(myRNA, c("gene1", "gene2", "gene3", "gene4"), "clustering",
 #'     mid.color = "rgb"
 #' )
 #' dittoDotPlot(myRNA, c("gene1", "gene2", "gene3", "gene4"), "clustering",
-#'     min.color = "blue",
-#'     mid.color = "gray90",
-#'     max.color = "red"
+#'     min.color = "#2166AC", # (blue)
+#'     mid.color = "gray97",  # (gray)
+#'     max.color = "#B2182B"  # (red)
 #' )
 #'
 #' # For certain specialized applications, it may be helpful to adjust the
@@ -281,15 +283,20 @@ dittoDotPlot <- function(
         min,
         default = if (scale) {NA} else {0})
     if (!identical(mid.color, NULL)) {
+        if (mid.color == "ryb") {
+            min.color <- "#4575B4"
+            mid.color <- "#FFFFBF"
+            max.color <- "#D73027"
+        }
         if (mid.color == "rgb") {
-            min.color <- "blue"
-            mid.color <- "gray90"
-            max.color <- "red"
+            min.color <- "#2166AC"
+            mid.color <- "gray97"
+            max.color <- "#B2182B"
         }
         if (mid.color == "rwb") {
-            min.color <- "blue"
+            min.color <- "#2166AC"
             mid.color <- "white"
-            max.color <- "red"
+            max.color <- "#B2182B"
         }
     }
     

--- a/R/utils-defaulting.R
+++ b/R/utils-defaulting.R
@@ -22,7 +22,7 @@
     #  - NULL when logical provided to 'null.if' is TRUE.
     #  - 'target' otherwise
     if (!is.null(target)) {
-        if (target==default.when) {
+        if (identical(target,default.when)) {
             if (null.if) {
                 target <- NULL
             } else {

--- a/man/dittoDotPlot.Rd
+++ b/man/dittoDotPlot.Rd
@@ -22,6 +22,8 @@ dittoDotPlot(
   max.color = "#C51B7D",
   min = "make",
   max = NA,
+  mid.color = NULL,
+  mid = "make",
   summary.fxn.color = function(x) {
      mean(x[x != 0])
  },
@@ -98,9 +100,30 @@ For options, when giving 1 metadata to \code{split.by}, see \code{\link[ggplot2]
 OR when giving 2 metadatas to \code{split.by}, see \code{\link[ggplot2]{facet_grid}}.}
 
 \item{min.color, max.color}{colors to use for minimum and maximum color values.
-Default = light grey and purple.}
+Default = light grey and purple.
+Ignored if \code{mid.color} given as \code{"rwb"} or \code{"rgb"} which will update these to be "blue" and "red", respectively.}
 
 \item{min, max}{Numbers which set the values associated with the minimum and maximum colors.}
+
+\item{mid.color}{NULL (default), "rwb", "rgb", or a color to use for the midpoint of a three-color color scale.
+\emph{This parameter acts a switch between using a 2-color scale or a 3-color scale}:\itemize{
+\item When left NULL, the 2-color scale runs from \code{min.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient}}.
+\item When given a color, the 3-color scale runs from \code{min.color} to \code{mid.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient2}}.
+\item{
+When given \emph{\code{"rwb"} or \code{"rgb"} serves as a \strong{single-point, quick switch to a "standard" 3-color scale}} by also updating the \code{min.color} and \code{max.color} used:
+Doing so sets:\itemize{
+    \item "red" as the \code{max.color},
+    \item "blue" as the \code{min.color},
+    \item and either "white" ("r\emph{w}b") or "gray90" ("r\emph{g}b") for \code{mid.color}.
+}
+Thus, the 3-color scale runs from "blue" to either "white" or "gray90" to "red", using \code{\link[ggplot2]{scale_fill_gradient2}}.
+}
+}}
+
+\item{mid}{Number or "make" (default) which sets the value associated with the \code{mid.color} of the three-color scale.
+Ignored when \code{mid.color} is left as NULL.
+When "make", defaults to midway between what dittoSeq expects to be the minimum and maximum values shown in the legend.
+(Maps to the 'midpoint' parameter of \code{\link[ggplot2]{scale_fill_gradient2}}.)}
 
 \item{summary.fxn.color, summary.fxn.size}{A function which sets how color or size will be used to summarize variables' data for each group.
 Any function can be used as long as it takes in a numeric vector and returns a single numeric value.}
@@ -201,7 +224,8 @@ Labels along the x-axis can be rotated 45 degrees with \code{x.label.rotate=TRUE
 \item Size of the dots can be changed with \code{size}.
 \item Subsetting to utilize only certain cells/samples can be achieved with \code{cells.use}.
 \item Markers can be grouped into categories by providing them to the \code{vars} input as a list, where list element names represent category names, and list element contents are the feature names which each category should contain.
-\item Colors can be adjusted with \code{min.color} and \code{max.color}.
+\item Colors (2-color scale) can be adjusted with \code{min.color} and \code{max.color}.
+\item Coloring can also be switched to a 3-color scale by using the \code{mid.color} parameter.  For details, see that parameter's description above.
 \item Displayed value ranges can be adjusted with \code{min} and \code{max} for color, or \code{min.percent} and \code{max.percent} for size.
 \item Titles and axes labels can be adjusted with \code{main}, \code{sub}, \code{xlab}, \code{ylab}, \code{legend.color.title}, and \code{legend.size.title} arguments.
 \item The legend can be hidden by setting \code{legend.show = FALSE}.
@@ -284,6 +308,22 @@ dittoDotPlot(myRNA, group.by = "clustering",
     vars = list(Naive = c("gene1", "gene2"), Stimulated = c("gene3")),
     split.by = "conditions",
     vars.dir = "y"
+)
+
+# Coloring can be swapped from the default 2-color scale to a 3-color scale
+#   by using the 'mid.color' input:
+dittoDotPlot(myRNA, c("gene1", "gene2", "gene3", "gene4"), "clustering",
+    mid.color = "white"
+)
+# Setting it to "rgb" or "rwb" quickly updates 'min.color' and 'max.color' too,
+#   making the affect of these next two calls equivalent:
+dittoDotPlot(myRNA, c("gene1", "gene2", "gene3", "gene4"), "clustering",
+    mid.color = "rgb"
+)
+dittoDotPlot(myRNA, c("gene1", "gene2", "gene3", "gene4"), "clustering",
+    min.color = "blue",
+    mid.color = "gray90",
+    max.color = "red"
 )
 
 # For certain specialized applications, it may be helpful to adjust the

--- a/man/dittoDotPlot.Rd
+++ b/man/dittoDotPlot.Rd
@@ -101,22 +101,23 @@ OR when giving 2 metadatas to \code{split.by}, see \code{\link[ggplot2]{facet_gr
 
 \item{min.color, max.color}{colors to use for minimum and maximum color values.
 Default = light grey and purple.
-Ignored if \code{mid.color} given as \code{"rwb"} or \code{"rgb"} which will update these to be "blue" and "red", respectively.}
+Ignored if \code{mid.color} given as \code{"ryb"}, \code{"rwb"}, or \code{"rgb"} which will update these to be "blue" and "red", respectively.}
 
 \item{min, max}{Numbers which set the values associated with the minimum and maximum colors.}
 
-\item{mid.color}{NULL (default), "rwb", "rgb", or a color to use for the midpoint of a three-color color scale.
+\item{mid.color}{NULL (default), "ryb", "rwb", "rgb", or a color to use for the midpoint of a three-color color scale.
 \emph{This parameter acts a switch between using a 2-color scale or a 3-color scale}:\itemize{
 \item When left NULL, the 2-color scale runs from \code{min.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient}}.
 \item When given a color, the 3-color scale runs from \code{min.color} to \code{mid.color} to \code{max.color}, using \code{\link[ggplot2]{scale_fill_gradient2}}.
 \item{
-When given \emph{\code{"rwb"} or \code{"rgb"} serves as a \strong{single-point, quick switch to a "standard" 3-color scale}} by also updating the \code{min.color} and \code{max.color} used:
+When given \emph{\code{"ryb"}, \code{"rwb"}, or \code{"rgb"} serves as a \strong{single-point, quick switch to a "standard" 3-color scale}} by also updating the \code{min.color} and \code{max.color}.
 Doing so sets:\itemize{
-    \item "red" as the \code{max.color},
-    \item "blue" as the \code{min.color},
-    \item and either "white" ("r\emph{w}b") or "gray90" ("r\emph{g}b") for \code{mid.color}.
+    \item \code{max.color} to a red,
+    \item \code{min.color} to a blue,
+    \item and \code{mid.color} to either a yellow ("r\emph{y}b"), "white" ("r\emph{w}b"), or "gray97" ("r\emph{g}b", gray not green).
+    \item Actual colors used are inspired by \href{http://www.colorbrewer.org}{ColorBrewer} "RdYlBu" and "RdBu" palettes.
 }
-Thus, the 3-color scale runs from "blue" to either "white" or "gray90" to "red", using \code{\link[ggplot2]{scale_fill_gradient2}}.
+Thus, the 3-color scale runs from a blue to one of a yellow, "white", or "gray97" to a red, using \code{\link[ggplot2]{scale_fill_gradient2}}.
 }
 }}
 
@@ -315,15 +316,16 @@ dittoDotPlot(myRNA, group.by = "clustering",
 dittoDotPlot(myRNA, c("gene1", "gene2", "gene3", "gene4"), "clustering",
     mid.color = "white"
 )
-# Setting it to "rgb" or "rwb" quickly updates 'min.color' and 'max.color' too,
-#   making the affect of these next two calls equivalent:
+# Setting it to "ryb", "rgb", or "rwb" quickly updates this input as well as
+#   'min.color' and 'max.color', making the affect of these next two calls
+#   equivalent:
 dittoDotPlot(myRNA, c("gene1", "gene2", "gene3", "gene4"), "clustering",
     mid.color = "rgb"
 )
 dittoDotPlot(myRNA, c("gene1", "gene2", "gene3", "gene4"), "clustering",
-    min.color = "blue",
-    mid.color = "gray90",
-    max.color = "red"
+    min.color = "#2166AC", # (blue)
+    mid.color = "gray97",  # (gray)
+    max.color = "#B2182B"  # (red)
 )
 
 # For certain specialized applications, it may be helpful to adjust the

--- a/tests/testthat/test-DotPlot.R
+++ b/tests/testthat/test-DotPlot.R
@@ -339,3 +339,45 @@ test_that("dittoDotPlot allows var-category grouping", {
             ),
         "ggplot")
 })
+
+test_that("dittoDotPlot allows 3-color scale", {
+    # Just mid.color / mid.value set
+    expect_s3_class(
+        dittoDotPlot(sce, genes, "groups",
+            mid.color = "white"),
+        "ggplot")
+
+    # "rgb" or "rwb"
+    ### Manual Check:
+    # First has gray in middle of legend
+    # Second has white in middle of legend
+    # Both have blue at bottom and red at top of legend
+    expect_s3_class(
+        dittoDotPlot(sce, genes, "groups",
+            mid.color = "rgb"),
+        "ggplot")
+    expect_s3_class(
+        dittoDotPlot(sce, genes, "groups",
+            mid.color = "rwb"),
+        "ggplot")
+
+    ## Edge-cases
+    # No scaling.  mid defaults to 0
+    expect_s3_class(
+        dittoDotPlot(sce, genes, "groups",
+            mid.color = "white",
+            scale = FALSE),
+        "ggplot")
+    # No scaling, but min NA, mid defaults to halfway between calc'd min and max
+    expect_s3_class(
+        dittoDotPlot(sce, genes, "groups",
+            mid.color = "white",
+            scale = FALSE, min = NA),
+        "ggplot")
+    # mid too high, colors plotted between min and mid only
+    expect_s3_class(
+        dittoDotPlot(sce, genes, "groups",
+            mid.color = "white",
+            mid = 1.5),
+        "ggplot")
+})

--- a/tests/testthat/test-DotPlot.R
+++ b/tests/testthat/test-DotPlot.R
@@ -347,11 +347,16 @@ test_that("dittoDotPlot allows 3-color scale", {
             mid.color = "white"),
         "ggplot")
 
-    # "rgb" or "rwb"
+    # "ryb", "rgb" or "rwb"
     ### Manual Check:
-    # First has gray in middle of legend
-    # Second has white in middle of legend
-    # Both have blue at bottom and red at top of legend
+    # First has yellow in middle of legend
+    # Second has near-white in middle of legend
+    # Third has white in middle of legend
+    # All have blue at bottom and red at top of legend
+    expect_s3_class(
+        dittoDotPlot(sce, genes, "groups",
+            mid.color = "ryb"),
+        "ggplot")
     expect_s3_class(
         dittoDotPlot(sce, genes, "groups",
             mid.color = "rgb"),
@@ -374,7 +379,8 @@ test_that("dittoDotPlot allows 3-color scale", {
             mid.color = "white",
             scale = FALSE, min = NA),
         "ggplot")
-    # mid too high, colors plotted between min and mid only
+    # mid too high, colors plotted between min and mid only because mid is
+    #   higher than the max of the data.
     expect_s3_class(
         dittoDotPlot(sce, genes, "groups",
             mid.color = "white",


### PR DESCRIPTION
This PR adds internal support for swapping `dittoDotPlot()` to use a 3-color scale.

Currently, use of a 3-color scale requires an external call to replace the fill scale, and thus loses connectivity with the function's `min`, `max`, `min.color`, `max.color`, `legend.color.breaks`, `legend.color.breaks.labels`, and `legend.color.title` input management.

Instead, this PR adds control via new inputs `mid.color` and `mid`, and allows `dittoDotPlot()` to swap as needed from passing input counterparts to `gpplot2::scale_fill_gradient()` (current, 2-color) versus `gpplot2::scale_fill_gradient2()` (new support, 3-color).
- `mid.color`: when not adjusted user gets current 2-color behavior. When given a color (string), or "rgb" or "rwb" specifically, function swaps to 3-color scale. "rgb" and "rwb" serve as a simple, single-input, provision mechanism for getting the effect of setting all of `max.color = "red", min.color = "blue", mid.color =  "gray90"` (or `"white"`).
- `mid`: `gpplot2::scale_fill_gradient2()`'s `midpoint` input equivalent, set to "make" to receive intuitive defaulting, or a number to choose a value directly.

ToDo:
- [x] develop certainty that this input mechanism is good -- the same system should be extendable to other visualizations in the future!
- [x] tests & initial documentation
- [x] finalize documentation